### PR TITLE
chore: Break dependency cycle between currency, baseCurrency, token and coin; strengthen the return type of equals method

### DIFF
--- a/packages/sg-sdk/src/entities/baseCurrency.ts
+++ b/packages/sg-sdk/src/entities/baseCurrency.ts
@@ -1,4 +1,3 @@
-import { Currency } from "./currency"
 import { invariant as assert } from "../utils/invariantHelper"
 
 /**
@@ -44,5 +43,5 @@ export abstract class BaseCurrency {
      * Returns whether this currency is functionally equivalent to the other currency
      * @param other the other currency
      */
-    public abstract equals(other: Currency): boolean
+    public abstract equals(other: BaseCurrency): boolean
 }

--- a/packages/sg-sdk/src/entities/coin.ts
+++ b/packages/sg-sdk/src/entities/coin.ts
@@ -1,5 +1,4 @@
 import { BaseCurrency } from "./baseCurrency"
-import { Currency } from "./currency"
 
 /**
  * Represents an Coin with some metadata.
@@ -12,7 +11,7 @@ export class Coin extends BaseCurrency {
      * Returns true if the two Coins are equivalent, i.e. have the same chainId
      * @param other other currency to compare
      */
-    public equals(other: Currency): boolean {
+    public equals(other: BaseCurrency): other is Coin {
         if (!(other instanceof Coin)) return false
         return this.chainId === other.chainId
     }

--- a/packages/sg-sdk/src/entities/token.ts
+++ b/packages/sg-sdk/src/entities/token.ts
@@ -1,6 +1,5 @@
 import { validateAndParseAddress } from "../utils/validateAndParseAddress"
 import { BaseCurrency } from "./baseCurrency"
-import { Currency } from "./currency"
 
 /**
  * Represents an ERC20 token with a unique address and some metadata.
@@ -20,7 +19,7 @@ export class Token extends BaseCurrency {
      * Returns true if the two tokens are equivalent, i.e. have the same chainId and address.
      * @param other other token to compare
      */
-    public equals(other: Currency): boolean {
+    public equals(other: BaseCurrency): other is Token {
         if (!(other instanceof Token)) return false
         return this.chainId === other.chainId && this.address === other.address
     }


### PR DESCRIPTION
Just a small thing, let me know what you think. The only benefit for the SDK consumer is the slightly stronger typing of the `equals` method on the `BaseCurrency` implementations.