### PR TITLE
chore: Add @layerzerolabs/covalent-sdk

### DIFF
--- a/packages/covalent-sdk/package.json
+++ b/packages/covalent-sdk/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@layerzerolabs/covalent-sdk",
+  "version": "0.0.8",
+  "main": "./dist/index.js",
+  "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "prebuild": "ts-node ./scripts/generateSDK.ts",
+    "build": "tsdx build",
+    "start": "tsdx watch",
+    "test": "tsdx test --passWithNoTests"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "BUSL-1.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LayerZero-Labs/sdk.git",
+    "directory": "packages/covalent-sdk"
+  },
+  "devDependencies": {
+    "json-schema-to-typescript": "^11.0.1",
+    "lodash": "^4.17.21",
+    "prettier": "^2.7.1",
+    "ts-node": "^10.9.1",
+    "tsdx": "^0.14.1",
+    "typescript": "^4.9.5",
+    "vitest": "^0.21.0"
+  },
+  "peerDependencies": {
+    "axios": "*"
+  }
+}

--- a/packages/covalent-sdk/readme.md
+++ b/packages/covalent-sdk/readme.md
@@ -1,0 +1,20 @@
+## Installation
+
+```sh
+yarn add @layerzerolabs/covalent-sdk
+or
+npm i @layerzerolabs/covalent-sdk
+```
+
+## Usage
+
+```typescript
+import {Covalent} from '@layerzerolabs/covalent-sdk';
+
+const client = new Covalent.Client(process.env.COVALENT_API_KEY);
+
+const result = await client.getTokenBalancesForAddress({
+  chainId: Covalent.ChainId.ETHEREUM,
+  address: '0x6d9F1a927CBcb5e2c28D13CA735bc6d6131406da',
+});
+```

--- a/packages/covalent-sdk/scripts/generateSDK.ts
+++ b/packages/covalent-sdk/scripts/generateSDK.ts
@@ -1,0 +1,166 @@
+import schema from "./schema.json"
+import { camelCase } from "lodash"
+import { compile } from "json-schema-to-typescript"
+import prettier from "prettier"
+import fs from "fs"
+import path from "path"
+
+// schema downloaded from
+// https://api.covalenthq.com/v1/openapiv2/v20220805105331/
+// todo: add zod
+
+function mapType({ type, name }: { name: string; type: string }) {
+    if (name === "chain_id") return "ChainId"
+    return type === "integer" ? "number" : type
+}
+function mapParamName(n: string) {
+    return camelCase(n)
+}
+
+function toUrlExpression(path: string, params: any[]) {
+    params.forEach((param) => {
+        path = path.replace(":" + param.name, "${" + mapParamName(param.name) + "}")
+    })
+    return "`" + path + "`"
+}
+
+function fixComponents<T>(schema: T): T {
+    // very naive - parser fails otherwise
+    return JSON.parse(JSON.stringify(schema).replaceAll("#/components/schemas/", "#/components/"))
+}
+
+Promise.all(
+    schema.map(async (def) => {
+        const methodName = camelCase(def.title)
+        const response = fixComponents(def.response)
+
+        const jsonSchema = {
+            ...response.schema,
+            description: def.description,
+            title: response.name,
+            components: response.components,
+        }
+
+        const responseType = def.response.name
+        const responseDeclaration = await compile(jsonSchema as any, responseType)
+
+        const jsDoc = `/**
+    * ${def.description.split("\n").join(" ")}
+    ${def.params.map((p) => `* @param ${mapParamName(p.name)} - ${p.description}`).join("\n")}  
+    */`
+
+        const args = "{" + def.params.map((p) => mapParamName(p.name)).join(", ") + "}"
+        const argsType = "{" + def.params.map((p) => `${mapParamName(p.name)}${p.required === false ? "?" : ""} :${mapType(p)}`).join(", ") + "}"
+
+        const queryParams = def.params
+            .filter((p) => p.pathParam === false)
+            .map((p) => `"${p.name}": ` + mapParamName(p.name))
+            .join(", ")
+
+        const signature = def.params.length ? `${args} : ${argsType}` : ""
+        const functionDeclaration = `
+    ${jsDoc}
+    async ${methodName}(${signature}) {
+        const url = ${toUrlExpression(def.path, def.params)};
+        const {data} = await this.http.get<CovalentResponse<${responseType}>>(url, {params:{${queryParams}}});
+        if(data.error){
+          throw new Error(data.error_message);
+        }
+        return data.data;
+    }`
+
+        const moduleCode = {
+            functionDeclaration,
+            responseDeclaration,
+        }
+
+        return moduleCode
+    })
+)
+    .then(async (modules) => {
+        const responseDeclaration = `type CovalentResponse<T> = {
+      data: T,
+      error: false,
+      error_code: null,
+      error_message: null,
+    } | {
+      data: null,
+      error: true,
+      error_code: unknown,
+      error_message: string
+    }`
+        const clientDeclaration = `
+    export class Client {
+        private http: Axios;
+        constructor(private apiKey: string, private baseURL = "https://api.covalenthq.com") {
+          this.http = axios.create({
+            baseURL,
+            params: {
+              key: apiKey,
+            },
+          });
+        }
+
+        ${modules.map((m) => m.functionDeclaration).join("\n\n")}
+    }`
+
+        const typesDeclaration = modules.map((m) => m.responseDeclaration).join("\n\n")
+
+        const fileName = path.resolve(__dirname, "../src/index.ts")
+        const prettierConfig = await prettier.resolveConfig(fileName)
+
+        const sourceCode = prettier.format(
+            `
+    // @ts-nocheck
+    import axios, {Axios} from 'axios';
+
+    export namespace Covalent {
+
+      export enum ChainId {
+        ETHEREUM = 1,
+        ETHEREUM_KOVAN = 42,
+        POLYGON = 137,
+        POLYGON_MUMBAI = 80001,
+        AVALANCHE = 43114,
+        AVALANCHE_FUJI = 43113,
+        BSC = 56,
+        BSC_TESTNET = 97,
+        FANTOM = 250,
+        FANTOM_TESTNET = 4002,
+        RONIN = 2020,
+        MOONBEAM_TESTNET = 1287,
+        MOONBEAM_POLKADOT = 1284,
+        MOONRIVER_KUSAMA = 1285,
+        RSK_MAINNET = 30,
+        RSK_TESTNET = 31,
+        ARBITRUM_MAINNET = 42161,
+        ARBITRUM_TESTNET = 421611,
+        PALM_MAINNET = 11297108109,
+        PALM_TESTNET = 11297108099,
+        KLAYTN_MAINNET_CYPRESS = 8217,
+        HECO_MAINNET = 128,
+        HECO_TESTNET = 256,
+        POLYJUICE_TESTNET = 71393,
+        IOTEX_MAINNET = 4689,
+        IOTEX_TESTNET = 4690,
+        EVMOS_TESTNET = 9000,
+        ASTAR_MAINNET = 592,
+        ASTAR_TESTNET = 81,
+        SHIDEN = 336,
+        HARMONY_MAINNET = 1666600000,
+        AURORA_MAINNET = 1313161554,
+        CRONOS_MAINNET = 25,
+        SOLANA = 1399811149,
+      }
+
+        export ${clientDeclaration};
+        export ${responseDeclaration}
+
+        ${typesDeclaration}
+    }`,
+            { ...prettierConfig, parser: "typescript" }
+        )
+
+        fs.writeFileSync(fileName, sourceCode)
+    })
+    .catch(console.error)

--- a/packages/covalent-sdk/scripts/schema.json
+++ b/packages/covalent-sdk/scripts/schema.json
@@ -1,0 +1,8946 @@
+[
+  {
+    "id": "1",
+    "title": "Get historical token prices",
+    "description": "Given `:chain_id` and `:contract_addresses`, return their historical prices. Can filter by date ranges and convert to `:quote_currency`. Only daily granularity is supported.",
+    "classType": "Pricing endpoints",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/pricing/historical_by_addresses_v2/:chain_id/:quote_currency/:contract_addresses/",
+    "released_at": "",
+    "order": 1,
+    "realTime": false,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "contract_addresses",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "quote_currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "from",
+        "description": "The start day of the historical price range. (YYYY-MM-DD)",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "to",
+        "description": "The end day of the historical price range. (YYYY-MM-DD)",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "prices-at-asc",
+        "description": "Sort the prices in chronological ascending order. By default, it's set to `false` and returns prices in chronological descending order.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [
+      {
+        "title": "Source for price feeds",
+        "description": "We rely on Coingecko for our source of token prices. Spot prices are updated every 10s and historical prices (daily granularity) are updated every day."
+      }
+    ],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "AddressWithHistoricalPricesItem",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "contract_decimals": {
+            "type": "integer",
+            "description": "Smart contract decimals.",
+            "format": "int32"
+          },
+          "contract_name": {
+            "type": "string",
+            "description": "Smart contract name."
+          },
+          "contract_ticker_symbol": {
+            "type": "string",
+            "description": "Smart contract ticker symbol."
+          },
+          "contract_address": {
+            "type": "string",
+            "description": "Smart contract address."
+          },
+          "supports_erc": {
+            "type": "array",
+            "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+            "items": {
+              "items": {
+                "type": "string",
+                "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+              }
+            }
+          },
+          "logo_url": {
+            "type": "string",
+            "description": "Smart contract URL."
+          },
+          "update_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "quote_currency": {
+            "type": "string"
+          },
+          "prices": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/HistoricalPriceItem"
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "ContractMetadata": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "supports_erc": {
+              "type": "array",
+              "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+              "items": {
+                "items": {
+                  "type": "string",
+                  "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+                }
+              }
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            }
+          }
+        },
+        "AddressWithHistoricalPricesItem": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "supports_erc": {
+              "type": "array",
+              "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+              "items": {
+                "items": {
+                  "type": "string",
+                  "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+                }
+              }
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "update_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "prices": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/HistoricalPriceItem"
+                }
+              }
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "HistoricalPriceItem": {
+          "type": "object",
+          "properties": {
+            "contract_metadata": {
+              "$ref": "#/components/schemas/ContractMetadata"
+            },
+            "date": {
+              "type": "string",
+              "format": "date"
+            },
+            "price": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get token balances for address",
+    "description": "Given `:chain_id` and wallet `:address`, return current token balances along with their spot prices. This endpoint supports a variety of token standards like ERC20, ERC721 and ERC1155. As a special case, network native tokens like ETH on Ethereum are also returned even though it's not a token contract.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/address/:address/balances_v2/",
+    "released_at": "2022-02-09",
+    "order": 1,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "nft",
+        "description": "Set to `true` to return ERC721 and ERC1155 assets. Defaults to `false`.",
+        "type": "boolean",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "no-nft-fetch",
+        "description": "Set to `true` to skip fetching NFT metadata, which can result in faster responses. Defaults to `false` and only applies when `nft=true`.",
+        "type": "boolean",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Basic example of fetching token balances on Ethereum (with ENS resolution)",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "address",
+            "value": "demo.eth"
+          }
+        ]
+      },
+      {
+        "description": "Basic example of fetching NFTs (ERC721 and ERC1155) on Ethereum",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "address",
+            "value": "demo.eth"
+          },
+          {
+            "name": "nft",
+            "value": "true"
+          }
+        ]
+      }
+    ],
+    "notes": [
+      {
+        "title": "🔥 Now supporting Solana",
+        "description": "Get token balances for any address on Solana using chain_id 1399811149."
+      },
+      {
+        "title": "No support for re-balancing tokens",
+        "description": "Tokens like Ampleforth (AMPL) that auto re-balance with custom scaling factors are not supported. "
+      },
+      {
+        "title": "Tokens classified as dust",
+        "description": "Tokens with less than $0.1 in spot fiat value get classified as dust. The developer is free to ignore/hide these tokens as they wish."
+      }
+    ],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "BalanceResponseType",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "The requested wallet address."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "next_update_at": {
+            "type": "string",
+            "description": "The next updated time.",
+            "format": "date-time"
+          },
+          "quote_currency": {
+            "type": "string",
+            "description": "The requested fiat currency."
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/WalletBalanceItem"
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "BalanceResponseType": {
+          "type": "object",
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "The requested wallet address."
+            },
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "next_update_at": {
+              "type": "string",
+              "description": "The next updated time.",
+              "format": "date-time"
+            },
+            "quote_currency": {
+              "type": "string",
+              "description": "The requested fiat currency."
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/WalletBalanceItem"
+                }
+              }
+            }
+          }
+        },
+        "INFTMetadata": {
+          "type": "object",
+          "description": "Array of NFTs that are held under this contract."
+        },
+        "WalletBalanceItem": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "supports_erc": {
+              "type": "array",
+              "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+              "items": {
+                "items": {
+                  "type": "string",
+                  "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+                }
+              }
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "last_transferred_at": {
+              "type": "string",
+              "description": "Last transferred date for a wallet",
+              "format": "date-time"
+            },
+            "native_token": {
+              "type": "boolean",
+              "description": "Indicates if a token is the chain's native gas token, eg: ETH on Ethereum."
+            },
+            "type": {
+              "type": "string",
+              "description": "One of `cryptocurrency`, `stablecoin`, `nft` or `dust`."
+            },
+            "balance": {
+              "type": "integer",
+              "description": "The asset balance. Use `contract_decimals` to scale this balance for display purposes."
+            },
+            "balance_24h": {
+              "type": "integer",
+              "description": "The asset balance 24 hours ago."
+            },
+            "quote_rate": {
+              "type": "number",
+              "description": "The current spot exchange rate in `quote-currency`.",
+              "format": "float"
+            },
+            "quote_rate_24h": {
+              "type": "number",
+              "description": "The spot exchange rate in `quote-currency` as of 24 hours ago.",
+              "format": "float"
+            },
+            "quote": {
+              "type": "number",
+              "description": "The current balance converted to fiat in `quote-currency`.",
+              "format": "float"
+            },
+            "quote_24h": {
+              "type": "number",
+              "description": "The current balance converted to fiat in `quote-currency` as of 24 hours ago.",
+              "format": "float"
+            },
+            "nft_data": {
+              "type": "array",
+              "description": "Array of NFTs that are held under this contract.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/INFTMetadata"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get historical portfolio value over time",
+    "description": "Given `:chain_id` and wallet `:address`, return wallet value for the last 30 days at 24 hour interval timestamps.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/address/:address/portfolio_v2/",
+    "released_at": "",
+    "order": 2,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "days",
+        "description": "The range of the historical portfolio in days, defaults to 30 days (max days = 2000).",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Basic example of fetching historical portfolio on Ethereum (with ENS resolution)",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "address",
+            "value": "demo.eth"
+          }
+        ]
+      }
+    ],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "HistoricalPortfolioResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "The requested wallet address."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "next_update_at": {
+            "type": "string",
+            "description": "The next updated time.",
+            "format": "date-time"
+          },
+          "quote_currency": {
+            "type": "string",
+            "description": "The requested fiat currency."
+          },
+          "chain_id": {
+            "type": "integer",
+            "description": "The requested chain ID.",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "description": "List of tokens in portfolio",
+            "items": {
+              "items": {
+                "type": "object",
+                "description": "List of tokens in portfolio"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "HistoricalPortfolioResponse": {
+          "type": "object",
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "The requested wallet address."
+            },
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "next_update_at": {
+              "type": "string",
+              "description": "The next updated time.",
+              "format": "date-time"
+            },
+            "quote_currency": {
+              "type": "string",
+              "description": "The requested fiat currency."
+            },
+            "chain_id": {
+              "type": "integer",
+              "description": "The requested chain ID.",
+              "format": "int64"
+            },
+            "items": {
+              "type": "array",
+              "description": "List of tokens in portfolio",
+              "items": {
+                "items": {
+                  "type": "object",
+                  "description": "List of tokens in portfolio"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get transactions for address",
+    "description": "Given `:chain_id` and wallet `:address`, return all transactions along with their decoded log events. This endpoint does a deep-crawl of the blockchain to retrieve all kinds of transactions that references the `:address` including indexed topics within the event logs.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/address/:address/transactions_v2/",
+    "released_at": "",
+    "order": 3,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "block-signed-at-asc",
+        "description": "Sort the transactions in chronological ascending order. By default, it's set to `false` and returns transactions in chronological descending order.",
+        "type": "boolean",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "no-logs",
+        "description": "Setting this to `true` will omit decoded event logs, resulting in lighter and faster responses. By default it's set to `false`.",
+        "type": "boolean",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Basic example of fetching transactions from an address on Ethereum with decoded log events",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "address",
+            "value": "0xa79E63e78Eec28741e711f89A672A4C40876Ebf3"
+          }
+        ]
+      }
+    ],
+    "notes": [
+      {
+        "title": "sender_logo_url field",
+        "description": "sender_logo_url may reference to a not found resource (return status 404)."
+      }
+    ],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "TransactionResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "The requested wallet address."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "next_update_at": {
+            "type": "string",
+            "description": "The next updated time.",
+            "format": "date-time"
+          },
+          "quote_currency": {
+            "type": "string",
+            "description": "The requested fiat currency."
+          },
+          "chain_id": {
+            "type": "integer",
+            "description": "The requested chain ID.",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "description": "The transactions.",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/BlockTransactionWithLogEvents"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "DecodedParamItem": {
+          "type": "object",
+          "description": "The parameters of the decoded item.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the parameter."
+            },
+            "type": {
+              "type": "string",
+              "description": "The type of the parameter."
+            },
+            "indexed": {
+              "type": "boolean",
+              "description": "The index of the parameter."
+            },
+            "decoded": {
+              "type": "boolean",
+              "description": "The decoded value of the parameter."
+            },
+            "value": {
+              "type": "object",
+              "description": "The value of the parameter."
+            }
+          }
+        },
+        "TransactionResponse": {
+          "type": "object",
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "The requested wallet address."
+            },
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "next_update_at": {
+              "type": "string",
+              "description": "The next updated time.",
+              "format": "date-time"
+            },
+            "quote_currency": {
+              "type": "string",
+              "description": "The requested fiat currency."
+            },
+            "chain_id": {
+              "type": "integer",
+              "description": "The requested chain ID.",
+              "format": "int64"
+            },
+            "items": {
+              "type": "array",
+              "description": "The transactions.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/BlockTransactionWithLogEvents"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "DecodedItem": {
+          "type": "object",
+          "description": "The decoded item.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the decoded item."
+            },
+            "signature": {
+              "type": "string",
+              "description": "The signature of the decoded item."
+            },
+            "params": {
+              "type": "array",
+              "description": "The parameters of the decoded item.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/DecodedParamItem"
+                }
+              }
+            }
+          }
+        },
+        "LogEventItem": {
+          "type": "object",
+          "description": "The log events.",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int64"
+            },
+            "tx_offset": {
+              "type": "integer",
+              "description": "The transaction offset.",
+              "format": "int64"
+            },
+            "log_offset": {
+              "type": "integer",
+              "description": "The log offset.",
+              "format": "int64"
+            },
+            "tx_hash": {
+              "type": "string",
+              "description": "The transaction hash."
+            },
+            "raw_log_topics": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "sender_contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "sender_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "sender_contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "sender_address": {
+              "type": "string",
+              "description": "The address of the sender."
+            },
+            "sender_address_label": {
+              "type": "string",
+              "description": "The label of the sender address."
+            },
+            "sender_logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "raw_log_data": {
+              "type": "string",
+              "description": "The log events in raw."
+            },
+            "decoded": {
+              "$ref": "#/components/schemas/DecodedItem"
+            }
+          }
+        },
+        "BlockTransactionWithLogEvents": {
+          "type": "object",
+          "description": "The transactions.",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int32"
+            },
+            "tx_hash": {
+              "type": "string",
+              "description": "The transaction hash."
+            },
+            "tx_offset": {
+              "type": "integer",
+              "description": "The transaction offset.",
+              "format": "int32"
+            },
+            "successful": {
+              "type": "boolean",
+              "description": "The transaction status."
+            },
+            "from_address": {
+              "type": "string",
+              "description": "The address where the transaction is from."
+            },
+            "from_address_label": {
+              "type": "string",
+              "description": "The label of `from` address."
+            },
+            "to_address": {
+              "type": "string",
+              "description": "The address where the transaction is to."
+            },
+            "to_address_label": {
+              "type": "string",
+              "description": "The label of `to` address."
+            },
+            "value": {
+              "type": "number",
+              "description": "The value attached to this tx."
+            },
+            "value_quote": {
+              "type": "number",
+              "description": "The value attached in `quote-currency` to this tx.",
+              "format": "double"
+            },
+            "gas_offered": {
+              "type": "integer",
+              "description": "The gas offered for this tx.",
+              "format": "int64"
+            },
+            "gas_spent": {
+              "type": "integer",
+              "description": "The gas spent for this tx.",
+              "format": "int64"
+            },
+            "gas_price": {
+              "type": "integer",
+              "description": "The gas price at the time of this tx.",
+              "format": "int64"
+            },
+            "fees_paid": {
+              "type": "number",
+              "description": "The total transaction fees paid for this tx."
+            },
+            "gas_quote": {
+              "type": "number",
+              "description": "The gas spent in `quote-currency` denomination.",
+              "format": "double"
+            },
+            "gas_quote_rate": {
+              "type": "number",
+              "description": "The gas exchange rate at the time of Tx in `quote_currency`.",
+              "format": "double"
+            },
+            "log_events": {
+              "type": "array",
+              "description": "The log events.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/LogEventItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get a transaction",
+    "description": "Given `:chain_id` and `:tx_hash`, return the transaction data with their decoded event logs.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/transaction_v2/:tx_hash/",
+    "released_at": "",
+    "order": 4,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "tx_hash",
+        "description": "Hex encoded transaction hash.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "no-logs",
+        "description": "Setting this to `true` will omit decoded event logs, resulting in lighter and faster responses. By default it's set to `false`.",
+        "type": "boolean",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Basic example of fetching a transaction of an Ethereum address",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "tx_hash",
+            "value": "0xbda92389200cadac424d64202caeab70cd5e93756fe34c08578adeb310bba254"
+          }
+        ]
+      }
+    ],
+    "notes": [
+      {
+        "title": "sender_logo_url field",
+        "description": "sender_logo_url may reference to a not found resource (return status 404)."
+      }
+    ],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "SingleTransactionResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/BlockTransactionWithLogEvents"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "SingleTransactionResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/BlockTransactionWithLogEvents"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "DecodedParamItem": {
+          "type": "object",
+          "description": "The parameters of the decoded item.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the parameter."
+            },
+            "type": {
+              "type": "string",
+              "description": "The type of the parameter."
+            },
+            "indexed": {
+              "type": "boolean",
+              "description": "The index of the parameter."
+            },
+            "decoded": {
+              "type": "boolean",
+              "description": "The decoded value of the parameter."
+            },
+            "value": {
+              "type": "object",
+              "description": "The value of the parameter."
+            }
+          }
+        },
+        "DecodedItem": {
+          "type": "object",
+          "description": "The decoded item.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the decoded item."
+            },
+            "signature": {
+              "type": "string",
+              "description": "The signature of the decoded item."
+            },
+            "params": {
+              "type": "array",
+              "description": "The parameters of the decoded item.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/DecodedParamItem"
+                }
+              }
+            }
+          }
+        },
+        "LogEventItem": {
+          "type": "object",
+          "description": "The log events.",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int64"
+            },
+            "tx_offset": {
+              "type": "integer",
+              "description": "The transaction offset.",
+              "format": "int64"
+            },
+            "log_offset": {
+              "type": "integer",
+              "description": "The log offset.",
+              "format": "int64"
+            },
+            "tx_hash": {
+              "type": "string",
+              "description": "The transaction hash."
+            },
+            "raw_log_topics": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "sender_contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "sender_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "sender_contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "sender_address": {
+              "type": "string",
+              "description": "The address of the sender."
+            },
+            "sender_address_label": {
+              "type": "string",
+              "description": "The label of the sender address."
+            },
+            "sender_logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "raw_log_data": {
+              "type": "string",
+              "description": "The log events in raw."
+            },
+            "decoded": {
+              "$ref": "#/components/schemas/DecodedItem"
+            }
+          }
+        },
+        "BlockTransactionWithLogEvents": {
+          "type": "object",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int32"
+            },
+            "tx_hash": {
+              "type": "string",
+              "description": "The transaction hash."
+            },
+            "tx_offset": {
+              "type": "integer",
+              "description": "The transaction offset.",
+              "format": "int32"
+            },
+            "successful": {
+              "type": "boolean",
+              "description": "The transaction status."
+            },
+            "from_address": {
+              "type": "string",
+              "description": "The address where the transaction is from."
+            },
+            "from_address_label": {
+              "type": "string",
+              "description": "The label of `from` address."
+            },
+            "to_address": {
+              "type": "string",
+              "description": "The address where the transaction is to."
+            },
+            "to_address_label": {
+              "type": "string",
+              "description": "The label of `to` address."
+            },
+            "value": {
+              "type": "number",
+              "description": "The value attached to this tx."
+            },
+            "value_quote": {
+              "type": "number",
+              "description": "The value attached in `quote-currency` to this tx.",
+              "format": "double"
+            },
+            "gas_offered": {
+              "type": "integer",
+              "description": "The gas offered for this tx.",
+              "format": "int64"
+            },
+            "gas_spent": {
+              "type": "integer",
+              "description": "The gas spent for this tx.",
+              "format": "int64"
+            },
+            "gas_price": {
+              "type": "integer",
+              "description": "The gas price at the time of this tx.",
+              "format": "int64"
+            },
+            "fees_paid": {
+              "type": "number",
+              "description": "The total transaction fees paid for this tx."
+            },
+            "gas_quote": {
+              "type": "number",
+              "description": "The gas spent in `quote-currency` denomination.",
+              "format": "double"
+            },
+            "gas_quote_rate": {
+              "type": "number",
+              "description": "The gas exchange rate at the time of Tx in `quote_currency`.",
+              "format": "double"
+            },
+            "log_events": {
+              "type": "array",
+              "description": "The log events.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/LogEventItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get ERC20 token transfers for address",
+    "description": "Given `:chain_id`, wallet `:address` and `:contract-address`, return all ERC20 token contract transfers along with their historical prices at the time of their transfer.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/address/:address/transfers_v2/",
+    "released_at": "",
+    "order": 5,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "contract-address",
+        "description": "Smart contract address.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "starting-block",
+        "description": "Starting block to define a block range.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "ending-block",
+        "description": "Ending block to define a block range.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": " Basic example to fetch transfer of USDC from an Ethereum address",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "address",
+            "value": "0x197e3eCCD00F07B18205753C638c3E59013A92bf"
+          },
+          {
+            "name": "contract-address",
+            "value": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          }
+        ]
+      }
+    ],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "TransferResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "The requested wallet address."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "next_update_at": {
+            "type": "string",
+            "description": "The next updated time.",
+            "format": "date-time"
+          },
+          "quote_currency": {
+            "type": "string",
+            "description": "The requested fiat currency."
+          },
+          "chain_id": {
+            "type": "integer",
+            "description": "The requested chain ID.",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "description": "The transactions.",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/BlockTransactionWithContractTransfers"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "MethodCallsForTransfers": {
+          "type": "object",
+          "description": "Additional details on which transfer events were invoked. Defaults to `true`.",
+          "properties": {
+            "sender_address": {
+              "type": "string",
+              "description": "The address of the sender."
+            },
+            "method": {
+              "type": "string",
+              "description": "The name of the decoded item."
+            }
+          }
+        },
+        "TransferResponse": {
+          "type": "object",
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "The requested wallet address."
+            },
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "next_update_at": {
+              "type": "string",
+              "description": "The next updated time.",
+              "format": "date-time"
+            },
+            "quote_currency": {
+              "type": "string",
+              "description": "The requested fiat currency."
+            },
+            "chain_id": {
+              "type": "integer",
+              "description": "The requested chain ID.",
+              "format": "int64"
+            },
+            "items": {
+              "type": "array",
+              "description": "The transactions.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/BlockTransactionWithContractTransfers"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "TokenTransferItem": {
+          "type": "object",
+          "description": "Transfer items.",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "tx_hash": {
+              "type": "string",
+              "description": "The transaction hash."
+            },
+            "from_address": {
+              "type": "string",
+              "description": "The address where the transfer is from."
+            },
+            "from_address_label": {
+              "type": "string",
+              "description": "The label of `from` address."
+            },
+            "to_address": {
+              "type": "string",
+              "description": "The address where the transfer is to."
+            },
+            "to_address_label": {
+              "type": "string",
+              "description": "The label of `to` address."
+            },
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "transfer_type": {
+              "type": "string",
+              "description": "IN/OUT."
+            },
+            "delta": {
+              "type": "number",
+              "description": "The delta attached to this transfer."
+            },
+            "balance": {
+              "type": "number",
+              "description": "The transfer balance. Use `contract_decimals` to scale this balance for display purposes."
+            },
+            "quote_rate": {
+              "type": "number",
+              "description": "The current spot exchange rate in `quote-currency`.",
+              "format": "double"
+            },
+            "delta_quote": {
+              "type": "number",
+              "description": "The current delta converted to fiat in `quote-currency`.",
+              "format": "double"
+            },
+            "balance_quote": {
+              "type": "number",
+              "description": "The current balance converted to fiat in `quote-currency`.",
+              "format": "double"
+            },
+            "method_calls": {
+              "type": "array",
+              "description": "Additional details on which transfer events were invoked. Defaults to `true`.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/MethodCallsForTransfers"
+                }
+              }
+            }
+          }
+        },
+        "BlockTransactionWithContractTransfers": {
+          "type": "object",
+          "description": "The transactions.",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int32"
+            },
+            "tx_hash": {
+              "type": "string",
+              "description": "The transaction hash."
+            },
+            "tx_offset": {
+              "type": "integer",
+              "description": "The transaction offset.",
+              "format": "int32"
+            },
+            "successful": {
+              "type": "boolean",
+              "description": "The transaction status."
+            },
+            "from_address": {
+              "type": "string",
+              "description": "The address where the transaction is from."
+            },
+            "from_address_label": {
+              "type": "string",
+              "description": "The label of `from` address."
+            },
+            "to_address": {
+              "type": "string",
+              "description": "The address where the transaction is to."
+            },
+            "to_address_label": {
+              "type": "string",
+              "description": "The label of `to` address."
+            },
+            "value": {
+              "type": "number",
+              "description": "The value attached to this tx."
+            },
+            "value_quote": {
+              "type": "number",
+              "description": "The value attached in `quote-currency` to this tx.",
+              "format": "double"
+            },
+            "gas_offered": {
+              "type": "integer",
+              "description": "The gas offered for this tx.",
+              "format": "int64"
+            },
+            "gas_spent": {
+              "type": "integer",
+              "description": "The gas spent for this tx.",
+              "format": "int64"
+            },
+            "gas_price": {
+              "type": "integer",
+              "description": "The gas price at the time of this tx.",
+              "format": "int64"
+            },
+            "fees_paid": {
+              "type": "number",
+              "description": "The total transaction fees paid for this tx."
+            },
+            "gas_quote": {
+              "type": "number",
+              "description": "The gas spent in `quote-currency` denomination.",
+              "format": "double"
+            },
+            "gas_quote_rate": {
+              "type": "number",
+              "description": "The gas exchange rate at the time of Tx in `quote_currency`.",
+              "format": "double"
+            },
+            "transfers": {
+              "type": "array",
+              "description": "Transfer items.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/TokenTransferItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get a block",
+    "description": "Given `:chain_id` and `:block_height`, return a single block at `:block_height`. If `:block_height` is set to the value `latest`, return the latest block available.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/block_v2/:block_height/",
+    "released_at": "",
+    "order": 6,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "block_height",
+        "description": "The height of the block.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Basic example to get latest block of Palm Mainnet",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "11297108109"
+          },
+          {
+            "name": "block_height",
+            "value": "latest"
+          }
+        ]
+      }
+    ],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "SingleBlockResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/Block"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "Block": {
+          "type": "object",
+          "properties": {
+            "signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int32"
+            }
+          }
+        },
+        "SingleBlockResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/Block"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get block heights",
+    "description": "Given `:chain_id`, `:start_date` and `:end_date`, return all the block height(s) of a particular chain within a date range. If the `:end_date` is set to `latest`, return every block height from the `:start_date` to now.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/block_v2/:start_date/:end_date/",
+    "released_at": "",
+    "order": 7,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "start_date",
+        "description": "The start datetime of the block height(s). (yyyy-MM-ddTHH:mm:ssZ), eg: 2020-01-01 or 2020-01-01T03:36:50z",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "end_date",
+        "description": "The ending datetime of the block height(s). (yyyy-MM-ddTHH:mm:ssZ), eg: 2020-01-02 or 2020-01-02T03:36:50z",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Basic example of retrieving block heights given a certain date range",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "start_date",
+            "value": "2021-01-01"
+          },
+          {
+            "name": "end_date",
+            "value": "2021-01-03"
+          }
+        ]
+      }
+    ],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "SingleBlockResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/Block"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "Block": {
+          "type": "object",
+          "properties": {
+            "signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int32"
+            }
+          }
+        },
+        "SingleBlockResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/Block"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K pools",
+    "description": "Given `:chain_id` and `:dexname`, return pool information across all `XY=K` pools including LP token prices, reserves, exchange volumes and fees.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/:chain_id/xy=k/:dexname/pools/",
+    "released_at": "",
+    "order": 8,
+    "realTime": false,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "dexname",
+        "description": "One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": [
+          "uniswap_v2",
+          "sushiswap",
+          "pancakeswap_v2",
+          "quickswap",
+          "pangolin",
+          "spiritswap",
+          "spookyswap",
+          "traderjoe",
+          "standard",
+          "apeswap_v2",
+          "katana",
+          "stellaswap",
+          "beamswap"
+        ]
+      },
+      {
+        "name": "contract-addresses",
+        "description": "If `contract-addresses` (a comma separated list) is present, only return the pools that contain these contracts.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "tickers",
+        "description": "If `tickers` (a comma separated list) is present, only return the pools that contain these tickers.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/uniswap.png",
+        "id": "uniswapv2",
+        "name": "Uniswap V2",
+        "supportedChains": ["ethereum-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/sushi.png",
+        "id": "sushiswap",
+        "name": "SushiSwap",
+        "supportedChains": [
+          "ethereum-mainnet",
+          "matic-mainnet",
+          "fantom-mainnet",
+          "fantom-testnet",
+          "avalanche-testnet",
+          "avalanche-mainnet",
+          "bsc-mainnet",
+          "matic-mumbai"
+        ]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pancakeswap.png",
+        "id": "pancakeswap",
+        "name": "PancakeSwap",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/spiritswap.png",
+        "id": "spiritswap",
+        "name": "SpiritSwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Spookyswap.png",
+        "id": "spookyswap",
+        "name": "SpookySwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Quickswap.png",
+        "id": "quickswap",
+        "name": "QuickSwap",
+        "supportedChains": ["matic-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ApeSwap.png",
+        "id": "apeswapv2",
+        "name": "ApeSwap V2",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pangolin.png",
+        "id": "pangolin",
+        "name": "Pangolin",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trader Joe.png",
+        "id": "traderjoe",
+        "name": "Trader Joe",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Standard.png",
+        "id": "standard",
+        "name": "Standard",
+        "supportedChains": ["astar-shiden"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Katana.png",
+        "id": "katana",
+        "name": "Katana",
+        "supportedChains": ["axie-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Stellaswap.png",
+        "id": "stellaswap",
+        "name": "StellaSwap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Beamswap.png",
+        "id": "beamswap",
+        "name": "Beamswap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Empire.png",
+        "id": "empire",
+        "name": "Empire",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Moonlift.png",
+        "id": "moonlift",
+        "name": "MoonLift",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mimo.png",
+        "id": "mimo",
+        "name": "Mimo",
+        "supportedChains": ["iotex-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Claimswap.png",
+        "id": "claimswap",
+        "name": "Claimswap",
+        "supportedChains": ["klaytn-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/WannaSwap.png",
+        "id": "wannaswap",
+        "name": "Wannaswap",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trisolaris.png",
+        "id": "trisolaris",
+        "name": "Trisolaris",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Diffusion.png",
+        "id": "diffusion",
+        "name": "Diffusion",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Cronus.png",
+        "id": "cronus",
+        "name": "Cronus",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Evmoswap.png",
+        "id": "evmoswap",
+        "name": "EVMOSwap",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ArthSwap.png",
+        "id": "arthswap",
+        "name": "ArthSwap",
+        "supportedChains": ["astar-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mmf.png",
+        "id": "mmf",
+        "name": "Mad Meerkat Finance",
+        "supportedChains": ["cronos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/VVSFinancial.png",
+        "id": "vvs",
+        "name": "VVS Finance",
+        "supportedChains": ["cronos-mainnet"]
+      }
+    ],
+    "response": {
+      "status": 200,
+      "name": "UniswapLikeExchangeListResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/ExchangeVolumeV2"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "UniswapLikeExchangeListResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/ExchangeVolumeV2"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "ExchangeVolumeV2": {
+          "type": "object",
+          "properties": {
+            "exchange": {
+              "type": "string"
+            },
+            "swap_count_24h": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "total_liquidity_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "volume_24h_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "fee_24h_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "total_supply": {
+              "type": "integer"
+            },
+            "quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "block_height": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "token_0": {
+              "$ref": "#/components/schemas/TokenV2"
+            },
+            "token_1": {
+              "$ref": "#/components/schemas/TokenV2"
+            },
+            "chain_name": {
+              "type": "string"
+            },
+            "chain_id": {
+              "type": "string"
+            },
+            "dex_name": {
+              "type": "string"
+            },
+            "volume_7d_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "annualized_fee": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        "TokenV2": {
+          "type": "object",
+          "properties": {
+            "contract_address": {
+              "type": "string"
+            },
+            "contract_name": {
+              "type": "string"
+            },
+            "volume_in_24h": {
+              "type": "number"
+            },
+            "volume_out_24h": {
+              "type": "number"
+            },
+            "quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "reserve": {
+              "type": "integer"
+            },
+            "logo_url": {
+              "type": "string"
+            },
+            "contract_ticker_symbol": {
+              "type": "string"
+            },
+            "contract_decimals": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "volume_in_7d": {
+              "type": "number"
+            },
+            "volume_out_7d": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get log events by contract address",
+    "description": "Given `:chain_id` and contract `:address`, return a paginated list of decoded log events emitted by a particular smart contract.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/events/address/:address/",
+    "released_at": "",
+    "order": 8,
+    "realTime": true,
+    "websocketSupport": true,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "starting-block",
+        "description": "Starting block to define a block range.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "ending-block",
+        "description": "Ending block to define a block range. Passing in `latest` uses the latest block height.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Basic example to fetch log events of a contract address between two block heights",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "address",
+            "value": "0xc0da01a04c3f3e0be433606045bb7017a7323e38"
+          },
+          {
+            "name": "starting-block",
+            "value": "12115107"
+          },
+          {
+            "name": "ending-block",
+            "value": "12240004"
+          }
+        ]
+      }
+    ],
+    "notes": [
+      {
+        "title": "sender_logo_url field",
+        "description": "sender_logo_url may reference to a not found resource (return status 404)."
+      }
+    ],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "EventsListResponseType",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/LogEventItem"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "DecodedParamItem": {
+          "type": "object",
+          "description": "The parameters of the decoded item.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the parameter."
+            },
+            "type": {
+              "type": "string",
+              "description": "The type of the parameter."
+            },
+            "indexed": {
+              "type": "boolean",
+              "description": "The index of the parameter."
+            },
+            "decoded": {
+              "type": "boolean",
+              "description": "The decoded value of the parameter."
+            },
+            "value": {
+              "type": "object",
+              "description": "The value of the parameter."
+            }
+          }
+        },
+        "EventsListResponseType": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/LogEventItem"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "DecodedItem": {
+          "type": "object",
+          "description": "The decoded item.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the decoded item."
+            },
+            "signature": {
+              "type": "string",
+              "description": "The signature of the decoded item."
+            },
+            "params": {
+              "type": "array",
+              "description": "The parameters of the decoded item.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/DecodedParamItem"
+                }
+              }
+            }
+          }
+        },
+        "LogEventItem": {
+          "type": "object",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int64"
+            },
+            "tx_offset": {
+              "type": "integer",
+              "description": "The transaction offset.",
+              "format": "int64"
+            },
+            "log_offset": {
+              "type": "integer",
+              "description": "The log offset.",
+              "format": "int64"
+            },
+            "tx_hash": {
+              "type": "string",
+              "description": "The transaction hash."
+            },
+            "raw_log_topics": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "sender_contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "sender_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "sender_contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "sender_address": {
+              "type": "string",
+              "description": "The address of the sender."
+            },
+            "sender_address_label": {
+              "type": "string",
+              "description": "The label of the sender address."
+            },
+            "sender_logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "raw_log_data": {
+              "type": "string",
+              "description": "The log events in raw."
+            },
+            "decoded": {
+              "$ref": "#/components/schemas/DecodedItem"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K pools by address",
+    "description": "Given `:chain_id`, `:dexname` and `:address`, return pool information across all `XY=K` pools including LP token prices, reserves, exchange volumes and fees for address.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/:chain_id/xy=k/:dexname/pools/address/:address/",
+    "released_at": "",
+    "order": 9,
+    "realTime": false,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "dexname",
+        "description": "One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": [
+          "uniswap_v2",
+          "sushiswap",
+          "pancakeswap_v2",
+          "quickswap",
+          "pangolin",
+          "spiritswap",
+          "spookyswap",
+          "traderjoe",
+          "standard",
+          "apeswap_v2",
+          "katana",
+          "stellaswap",
+          "beamswap"
+        ]
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "tickers",
+        "description": "If `tickers` (a comma separated list) is present, only return the pools that contain these tickers.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/uniswap.png",
+        "id": "uniswapv2",
+        "name": "Uniswap V2",
+        "supportedChains": ["ethereum-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/sushi.png",
+        "id": "sushiswap",
+        "name": "SushiSwap",
+        "supportedChains": [
+          "ethereum-mainnet",
+          "matic-mainnet",
+          "fantom-mainnet",
+          "fantom-testnet",
+          "avalanche-testnet",
+          "avalanche-mainnet",
+          "bsc-mainnet",
+          "matic-mumbai"
+        ]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pancakeswap.png",
+        "id": "pancakeswap",
+        "name": "PancakeSwap",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/spiritswap.png",
+        "id": "spiritswap",
+        "name": "SpiritSwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Spookyswap.png",
+        "id": "spookyswap",
+        "name": "SpookySwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Quickswap.png",
+        "id": "quickswap",
+        "name": "QuickSwap",
+        "supportedChains": ["matic-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ApeSwap.png",
+        "id": "apeswapv2",
+        "name": "ApeSwap V2",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pangolin.png",
+        "id": "pangolin",
+        "name": "Pangolin",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trader Joe.png",
+        "id": "traderjoe",
+        "name": "Trader Joe",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Standard.png",
+        "id": "standard",
+        "name": "Standard",
+        "supportedChains": ["astar-shiden"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Katana.png",
+        "id": "katana",
+        "name": "Katana",
+        "supportedChains": ["axie-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Stellaswap.png",
+        "id": "stellaswap",
+        "name": "StellaSwap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Beamswap.png",
+        "id": "beamswap",
+        "name": "Beamswap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Empire.png",
+        "id": "empire",
+        "name": "Empire",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Moonlift.png",
+        "id": "moonlift",
+        "name": "MoonLift",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mimo.png",
+        "id": "mimo",
+        "name": "Mimo",
+        "supportedChains": ["iotex-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Claimswap.png",
+        "id": "claimswap",
+        "name": "Claimswap",
+        "supportedChains": ["klaytn-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/WannaSwap.png",
+        "id": "wannaswap",
+        "name": "Wannaswap",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trisolaris.png",
+        "id": "trisolaris",
+        "name": "Trisolaris",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Diffusion.png",
+        "id": "diffusion",
+        "name": "Diffusion",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Cronus.png",
+        "id": "cronus",
+        "name": "Cronus",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Evmoswap.png",
+        "id": "evmoswap",
+        "name": "EVMOSwap",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ArthSwap.png",
+        "id": "arthswap",
+        "name": "ArthSwap",
+        "supportedChains": ["astar-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mmf.png",
+        "id": "mmf",
+        "name": "Mad Meerkat Finance",
+        "supportedChains": ["cronos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/VVSFinancial.png",
+        "id": "vvs",
+        "name": "VVS Finance",
+        "supportedChains": ["cronos-mainnet"]
+      }
+    ],
+    "response": {
+      "status": 200,
+      "name": "UniswapLikeExchangeListResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/ExchangeVolumeV2"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "UniswapLikeExchangeListResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/ExchangeVolumeV2"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "ExchangeVolumeV2": {
+          "type": "object",
+          "properties": {
+            "exchange": {
+              "type": "string"
+            },
+            "swap_count_24h": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "total_liquidity_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "volume_24h_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "fee_24h_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "total_supply": {
+              "type": "integer"
+            },
+            "quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "block_height": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "token_0": {
+              "$ref": "#/components/schemas/TokenV2"
+            },
+            "token_1": {
+              "$ref": "#/components/schemas/TokenV2"
+            },
+            "chain_name": {
+              "type": "string"
+            },
+            "chain_id": {
+              "type": "string"
+            },
+            "dex_name": {
+              "type": "string"
+            },
+            "volume_7d_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "annualized_fee": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        "TokenV2": {
+          "type": "object",
+          "properties": {
+            "contract_address": {
+              "type": "string"
+            },
+            "contract_name": {
+              "type": "string"
+            },
+            "volume_in_24h": {
+              "type": "number"
+            },
+            "volume_out_24h": {
+              "type": "number"
+            },
+            "quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "reserve": {
+              "type": "integer"
+            },
+            "logo_url": {
+              "type": "string"
+            },
+            "contract_ticker_symbol": {
+              "type": "string"
+            },
+            "contract_decimals": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "volume_in_7d": {
+              "type": "number"
+            },
+            "volume_out_7d": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get log events by topic hash(es)",
+    "description": "Given `:chain_id` and `:topic` hash(es), return a paginated list of decoded log events with one or more topic hashes separated by a comma.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/events/topics/:topic/",
+    "released_at": "",
+    "order": 9,
+    "realTime": true,
+    "websocketSupport": true,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "topic",
+        "description": "Topic hash value from log records.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "secondary-topics",
+        "description": "Additional topic hash(es) to filter on -- padded & unpadded address fields are supported.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "starting-block",
+        "description": "Starting block to define a block range.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "ending-block",
+        "description": "Ending block to define a block range. Passing in `latest` uses the latest block height.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "sender-address",
+        "description": "The address of the sender.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Basic example to fetch a topic hash between two block heights on Ethereum",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "topic",
+            "value": "0x804c9b842b2748a22bb64b345453a3de7ca54a6ca45ce00d415894979e22897a"
+          },
+          {
+            "name": "starting-block",
+            "value": "12500000"
+          },
+          {
+            "name": "ending-block",
+            "value": "12500100"
+          },
+          {
+            "name": "sender-address",
+            "value": "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9"
+          }
+        ]
+      }
+    ],
+    "notes": [
+      {
+        "title": "Topic hash details",
+        "description": "Topic hash can be calculated using our topic hash calculator in our documentation section."
+      },
+      {
+        "title": "sender_logo_url field",
+        "description": "sender_logo_url may reference to a not found resource (return status 404)."
+      }
+    ],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "EventsListResponseType",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/LogEventItem"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "DecodedParamItem": {
+          "type": "object",
+          "description": "The parameters of the decoded item.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the parameter."
+            },
+            "type": {
+              "type": "string",
+              "description": "The type of the parameter."
+            },
+            "indexed": {
+              "type": "boolean",
+              "description": "The index of the parameter."
+            },
+            "decoded": {
+              "type": "boolean",
+              "description": "The decoded value of the parameter."
+            },
+            "value": {
+              "type": "object",
+              "description": "The value of the parameter."
+            }
+          }
+        },
+        "EventsListResponseType": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/LogEventItem"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "DecodedItem": {
+          "type": "object",
+          "description": "The decoded item.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the decoded item."
+            },
+            "signature": {
+              "type": "string",
+              "description": "The signature of the decoded item."
+            },
+            "params": {
+              "type": "array",
+              "description": "The parameters of the decoded item.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/DecodedParamItem"
+                }
+              }
+            }
+          }
+        },
+        "LogEventItem": {
+          "type": "object",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int64"
+            },
+            "tx_offset": {
+              "type": "integer",
+              "description": "The transaction offset.",
+              "format": "int64"
+            },
+            "log_offset": {
+              "type": "integer",
+              "description": "The log offset.",
+              "format": "int64"
+            },
+            "tx_hash": {
+              "type": "string",
+              "description": "The transaction hash."
+            },
+            "raw_log_topics": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "sender_contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "sender_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "sender_contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "sender_address": {
+              "type": "string",
+              "description": "The address of the sender."
+            },
+            "sender_address_label": {
+              "type": "string",
+              "description": "The label of the sender address."
+            },
+            "sender_logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "raw_log_data": {
+              "type": "string",
+              "description": "The log events in raw."
+            },
+            "decoded": {
+              "$ref": "#/components/schemas/DecodedItem"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K address exchange balances",
+    "description": "Given `:chain_id`, `:dexname` and `:address`, return address exchange balances for a specific DEX.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/:chain_id/xy=k/:dexname/address/:address/balances/",
+    "released_at": "",
+    "order": 10,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "dexname",
+        "description": "One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": [
+          "uniswap_v2",
+          "sushiswap",
+          "pancakeswap_v2",
+          "quickswap",
+          "pangolin",
+          "spiritswap",
+          "spookyswap",
+          "traderjoe",
+          "standard",
+          "apeswap_v2",
+          "katana",
+          "stellaswap",
+          "beamswap"
+        ]
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/uniswap.png",
+        "id": "uniswapv2",
+        "name": "Uniswap V2",
+        "supportedChains": ["ethereum-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/sushi.png",
+        "id": "sushiswap",
+        "name": "SushiSwap",
+        "supportedChains": [
+          "ethereum-mainnet",
+          "matic-mainnet",
+          "fantom-mainnet",
+          "fantom-testnet",
+          "avalanche-testnet",
+          "avalanche-mainnet",
+          "bsc-mainnet",
+          "matic-mumbai"
+        ]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pancakeswap.png",
+        "id": "pancakeswap",
+        "name": "PancakeSwap",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/spiritswap.png",
+        "id": "spiritswap",
+        "name": "SpiritSwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Spookyswap.png",
+        "id": "spookyswap",
+        "name": "SpookySwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Quickswap.png",
+        "id": "quickswap",
+        "name": "QuickSwap",
+        "supportedChains": ["matic-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ApeSwap.png",
+        "id": "apeswapv2",
+        "name": "ApeSwap V2",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pangolin.png",
+        "id": "pangolin",
+        "name": "Pangolin",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trader Joe.png",
+        "id": "traderjoe",
+        "name": "Trader Joe",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Standard.png",
+        "id": "standard",
+        "name": "Standard",
+        "supportedChains": ["astar-shiden"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Katana.png",
+        "id": "katana",
+        "name": "Katana",
+        "supportedChains": ["axie-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Stellaswap.png",
+        "id": "stellaswap",
+        "name": "StellaSwap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Beamswap.png",
+        "id": "beamswap",
+        "name": "Beamswap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Empire.png",
+        "id": "empire",
+        "name": "Empire",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Moonlift.png",
+        "id": "moonlift",
+        "name": "MoonLift",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mimo.png",
+        "id": "mimo",
+        "name": "Mimo",
+        "supportedChains": ["iotex-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Claimswap.png",
+        "id": "claimswap",
+        "name": "Claimswap",
+        "supportedChains": ["klaytn-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/WannaSwap.png",
+        "id": "wannaswap",
+        "name": "Wannaswap",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trisolaris.png",
+        "id": "trisolaris",
+        "name": "Trisolaris",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Diffusion.png",
+        "id": "diffusion",
+        "name": "Diffusion",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Cronus.png",
+        "id": "cronus",
+        "name": "Cronus",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Evmoswap.png",
+        "id": "evmoswap",
+        "name": "EVMOSwap",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ArthSwap.png",
+        "id": "arthswap",
+        "name": "ArthSwap",
+        "supportedChains": ["astar-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mmf.png",
+        "id": "mmf",
+        "name": "Mad Meerkat Finance",
+        "supportedChains": ["cronos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/VVSFinancial.png",
+        "id": "vvs",
+        "name": "VVS Finance",
+        "supportedChains": ["cronos-mainnet"]
+      }
+    ],
+    "response": {
+      "status": 200,
+      "name": "BalanceResponseType",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "next_update_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "quote_currency": {
+            "type": "string"
+          },
+          "uniswap_v2": {
+            "$ref": "#/components/schemas/ContainerU"
+          }
+        }
+      },
+      "components": {
+        "UniswapV2BalanceItem": {
+          "type": "object",
+          "properties": {
+            "token_0": {
+              "$ref": "#/components/schemas/UniswapToken"
+            },
+            "token_1": {
+              "$ref": "#/components/schemas/UniswapToken"
+            },
+            "pool_token": {
+              "$ref": "#/components/schemas/UniswapTokenWithSupply"
+            }
+          }
+        },
+        "BalanceResponseType": {
+          "type": "object",
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "updated_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "next_update_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "uniswap_v2": {
+              "$ref": "#/components/schemas/ContainerU"
+            }
+          }
+        },
+        "UniswapTokenWithSupply": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "balance": {
+              "type": "integer",
+              "description": "Current balance."
+            },
+            "quote": {
+              "type": "number",
+              "description": "The current balance converted to fiat in `quote-currency`.",
+              "format": "float"
+            },
+            "quote_rate": {
+              "type": "number",
+              "description": "The current spot exchange rate in `quote-currency`.",
+              "format": "float"
+            },
+            "total_supply": {
+              "type": "integer",
+              "description": "Total supply of this pool token."
+            }
+          }
+        },
+        "ContainerU": {
+          "type": "object",
+          "properties": {
+            "balances": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapV2BalanceItem"
+                }
+              }
+            }
+          }
+        },
+        "UniswapToken": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "balance": {
+              "type": "integer",
+              "description": "Current balance."
+            },
+            "quote": {
+              "type": "number",
+              "description": "The current balance converted to fiat in `quote-currency`.",
+              "format": "float"
+            },
+            "quote_rate": {
+              "type": "number",
+              "description": "The current spot exchange rate in `quote-currency`.",
+              "format": "float"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get token holders as of any block height",
+    "description": "Given `:chain_id` and wallet `:address`, return a paginated list of token holders. If `:block-height` is omitted, the latest block is used.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/tokens/:address/token_holders/",
+    "released_at": "",
+    "order": 10,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "block-height",
+        "description": "Ending block to define a block range. Passing in `latest` uses the latest block height.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Basic example of a list of token holders for Theta Token",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "address",
+            "value": "0x3883f5e181fccaf8410fa61e12b59bad963fb645"
+          }
+        ]
+      }
+    ],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "TokenHolderResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/TokenHolder"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "TokenHolder": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "supports_erc": {
+              "type": "array",
+              "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+              "items": {
+                "items": {
+                  "type": "string",
+                  "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+                }
+              }
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "address": {
+              "type": "string",
+              "description": "The address of token holder."
+            },
+            "balance": {
+              "type": "number",
+              "description": "The balance of token holder."
+            },
+            "total_supply": {
+              "type": "integer",
+              "description": "The total supply of the token."
+            },
+            "block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int64"
+            }
+          }
+        },
+        "TokenHolderResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/TokenHolder"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get changes in token holders between two block heights",
+    "description": "Given `:chain_id` and wallet `:address`, return a paginated list of token holders and their current/historical balances, where the token balance of the token holder changes between `:starting-block` and `:ending-block`.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/tokens/:address/token_holders_changes/",
+    "released_at": "",
+    "order": 11,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "starting-block",
+        "description": "Starting block to define a block range.",
+        "type": "integer",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "ending-block",
+        "description": "Ending block to define a block range.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Basic example of changes in token holders of Theta token between two block_heights",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "address",
+            "value": "0x3883f5e181fccaf8410fa61e12b59bad963fb645"
+          },
+          {
+            "name": "starting-block",
+            "value": "12500100"
+          },
+          {
+            "name": "ending-block",
+            "value": "13210000"
+          }
+        ]
+      }
+    ],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "TokenHolderDiff",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "token_holder": {
+            "type": "string",
+            "description": "The token holder."
+          },
+          "prev_balance": {
+            "type": "number",
+            "description": "The starting block balance."
+          },
+          "prev_block_height": {
+            "type": "integer",
+            "description": "The starting block height.",
+            "format": "int64"
+          },
+          "next_balance": {
+            "type": "number",
+            "description": "The ending block balance."
+          },
+          "next_block_height": {
+            "type": "integer",
+            "description": "The ending block height.",
+            "format": "int64"
+          },
+          "diff": {
+            "type": "number",
+            "description": "The difference of the balance."
+          }
+        }
+      },
+      "components": {
+        "TokenHolderDiff": {
+          "type": "object",
+          "properties": {
+            "token_holder": {
+              "type": "string",
+              "description": "The token holder."
+            },
+            "prev_balance": {
+              "type": "number",
+              "description": "The starting block balance."
+            },
+            "prev_block_height": {
+              "type": "integer",
+              "description": "The starting block height.",
+              "format": "int64"
+            },
+            "next_balance": {
+              "type": "number",
+              "description": "The ending block balance."
+            },
+            "next_block_height": {
+              "type": "integer",
+              "description": "The ending block height.",
+              "format": "int64"
+            },
+            "diff": {
+              "type": "number",
+              "description": "The difference of the balance."
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K network exchange tokens",
+    "description": "Given `:chain_id` and `:dexname`, return network exchange tokens for a specific DEX.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/:chain_id/xy=k/:dexname/tokens/",
+    "released_at": "",
+    "order": 11,
+    "realTime": false,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "dexname",
+        "description": "One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": [
+          "uniswap_v2",
+          "sushiswap",
+          "pancakeswap_v2",
+          "quickswap",
+          "pangolin",
+          "spiritswap",
+          "spookyswap",
+          "traderjoe",
+          "standard",
+          "apeswap_v2",
+          "katana",
+          "stellaswap",
+          "beamswap"
+        ]
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/uniswap.png",
+        "id": "uniswapv2",
+        "name": "Uniswap V2",
+        "supportedChains": ["ethereum-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/sushi.png",
+        "id": "sushiswap",
+        "name": "SushiSwap",
+        "supportedChains": [
+          "ethereum-mainnet",
+          "matic-mainnet",
+          "fantom-mainnet",
+          "fantom-testnet",
+          "avalanche-testnet",
+          "avalanche-mainnet",
+          "bsc-mainnet",
+          "matic-mumbai"
+        ]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pancakeswap.png",
+        "id": "pancakeswap",
+        "name": "PancakeSwap",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/spiritswap.png",
+        "id": "spiritswap",
+        "name": "SpiritSwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Spookyswap.png",
+        "id": "spookyswap",
+        "name": "SpookySwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Quickswap.png",
+        "id": "quickswap",
+        "name": "QuickSwap",
+        "supportedChains": ["matic-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ApeSwap.png",
+        "id": "apeswapv2",
+        "name": "ApeSwap V2",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pangolin.png",
+        "id": "pangolin",
+        "name": "Pangolin",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trader Joe.png",
+        "id": "traderjoe",
+        "name": "Trader Joe",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Standard.png",
+        "id": "standard",
+        "name": "Standard",
+        "supportedChains": ["astar-shiden"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Katana.png",
+        "id": "katana",
+        "name": "Katana",
+        "supportedChains": ["axie-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Stellaswap.png",
+        "id": "stellaswap",
+        "name": "StellaSwap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Beamswap.png",
+        "id": "beamswap",
+        "name": "Beamswap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Empire.png",
+        "id": "empire",
+        "name": "Empire",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Moonlift.png",
+        "id": "moonlift",
+        "name": "MoonLift",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mimo.png",
+        "id": "mimo",
+        "name": "Mimo",
+        "supportedChains": ["iotex-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Claimswap.png",
+        "id": "claimswap",
+        "name": "Claimswap",
+        "supportedChains": ["klaytn-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/WannaSwap.png",
+        "id": "wannaswap",
+        "name": "Wannaswap",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trisolaris.png",
+        "id": "trisolaris",
+        "name": "Trisolaris",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Diffusion.png",
+        "id": "diffusion",
+        "name": "Diffusion",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Cronus.png",
+        "id": "cronus",
+        "name": "Cronus",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Evmoswap.png",
+        "id": "evmoswap",
+        "name": "EVMOSwap",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ArthSwap.png",
+        "id": "arthswap",
+        "name": "ArthSwap",
+        "supportedChains": ["astar-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mmf.png",
+        "id": "mmf",
+        "name": "Mad Meerkat Finance",
+        "supportedChains": ["cronos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/VVSFinancial.png",
+        "id": "vvs",
+        "name": "VVS Finance",
+        "supportedChains": ["cronos-mainnet"]
+      }
+    ],
+    "response": {
+      "status": 200,
+      "name": "NetworkExchangeTokenResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/TokenV2Volume"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "TokenV2Volume": {
+          "type": "object",
+          "properties": {
+            "chain_name": {
+              "type": "string"
+            },
+            "chain_id": {
+              "type": "string"
+            },
+            "dex_name": {
+              "type": "string"
+            },
+            "contract_address": {
+              "type": "string"
+            },
+            "contract_name": {
+              "type": "string"
+            },
+            "total_liquidity": {
+              "type": "integer"
+            },
+            "total_volume_24h": {
+              "type": "number"
+            },
+            "logo_url": {
+              "type": "string"
+            },
+            "contract_ticker_symbol": {
+              "type": "string"
+            },
+            "contract_decimals": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "swap_count_24h": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "total_liquidity_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "total_volume_24h_quote": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        "NetworkExchangeTokenResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/TokenV2Volume"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K supported DEXes",
+    "description": "Returns a list of DEXes currently supported by the XY=K endpoints.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/xy=k/supported_dexes/",
+    "released_at": "",
+    "order": 11,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "BalanceResponseType",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "next_update_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "quote_currency": {
+            "type": "string"
+          },
+          "uniswap_v2": {
+            "$ref": "#/components/schemas/ContainerU"
+          }
+        }
+      },
+      "components": {
+        "UniswapV2BalanceItem": {
+          "type": "object",
+          "properties": {
+            "token_0": {
+              "$ref": "#/components/schemas/UniswapToken"
+            },
+            "token_1": {
+              "$ref": "#/components/schemas/UniswapToken"
+            },
+            "pool_token": {
+              "$ref": "#/components/schemas/UniswapTokenWithSupply"
+            }
+          }
+        },
+        "BalanceResponseType": {
+          "type": "object",
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "updated_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "next_update_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "uniswap_v2": {
+              "$ref": "#/components/schemas/ContainerU"
+            }
+          }
+        },
+        "UniswapTokenWithSupply": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "balance": {
+              "type": "integer",
+              "description": "Current balance."
+            },
+            "quote": {
+              "type": "number",
+              "description": "The current balance converted to fiat in `quote-currency`.",
+              "format": "float"
+            },
+            "quote_rate": {
+              "type": "number",
+              "description": "The current spot exchange rate in `quote-currency`.",
+              "format": "float"
+            },
+            "total_supply": {
+              "type": "integer",
+              "description": "Total supply of this pool token."
+            }
+          }
+        },
+        "ContainerU": {
+          "type": "object",
+          "properties": {
+            "balances": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapV2BalanceItem"
+                }
+              }
+            }
+          }
+        },
+        "UniswapToken": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "balance": {
+              "type": "integer",
+              "description": "Current balance."
+            },
+            "quote": {
+              "type": "number",
+              "description": "The current balance converted to fiat in `quote-currency`.",
+              "format": "float"
+            },
+            "quote_rate": {
+              "type": "number",
+              "description": "The current spot exchange rate in `quote-currency`.",
+              "format": "float"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get NFT token IDs for contract",
+    "description": "Given `:chain_id` and `:contract_address`, return a list of all token IDs for the NFT contract on the blockchain.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/tokens/:contract_address/nft_token_ids/",
+    "released_at": "",
+    "order": 12,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "contract_address",
+        "description": "Smart contract address.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Get token IDs for Meme Ltd",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "contract_address",
+            "value": "0xe4605d46fd0b3f8329d936a8b258d69276cba264"
+          }
+        ]
+      }
+    ],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "TokenIdResponseType",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/TokenIdResponse"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "TokenIdResponseType": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/TokenIdResponse"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "TokenIdResponse": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "supports_erc": {
+              "type": "array",
+              "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+              "items": {
+                "items": {
+                  "type": "string",
+                  "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+                }
+              }
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "token_id": {
+              "type": "integer",
+              "description": "The list of token ids under the contract address."
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K single network exchange token",
+    "description": "Given `:chain_id`, `:dexname` and `:token_address`, return single network exchange token for a specific DEX.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/:chain_id/xy=k/:dexname/tokens/address/:token_address/",
+    "released_at": "",
+    "order": 12,
+    "realTime": false,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "token_address",
+        "description": "token address",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "dexname",
+        "description": "One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": [
+          "uniswap_v2",
+          "sushiswap",
+          "pancakeswap_v2",
+          "quickswap",
+          "pangolin",
+          "spiritswap",
+          "spookyswap",
+          "traderjoe",
+          "standard",
+          "apeswap_v2",
+          "katana",
+          "stellaswap",
+          "beamswap"
+        ]
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "tickers",
+        "description": "If `tickers` (a comma separated list) is present, only return the pools that contain these tickers.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/uniswap.png",
+        "id": "uniswapv2",
+        "name": "Uniswap V2",
+        "supportedChains": ["ethereum-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/sushi.png",
+        "id": "sushiswap",
+        "name": "SushiSwap",
+        "supportedChains": [
+          "ethereum-mainnet",
+          "matic-mainnet",
+          "fantom-mainnet",
+          "fantom-testnet",
+          "avalanche-testnet",
+          "avalanche-mainnet",
+          "bsc-mainnet",
+          "matic-mumbai"
+        ]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pancakeswap.png",
+        "id": "pancakeswap",
+        "name": "PancakeSwap",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/spiritswap.png",
+        "id": "spiritswap",
+        "name": "SpiritSwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Spookyswap.png",
+        "id": "spookyswap",
+        "name": "SpookySwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Quickswap.png",
+        "id": "quickswap",
+        "name": "QuickSwap",
+        "supportedChains": ["matic-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ApeSwap.png",
+        "id": "apeswapv2",
+        "name": "ApeSwap V2",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pangolin.png",
+        "id": "pangolin",
+        "name": "Pangolin",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trader Joe.png",
+        "id": "traderjoe",
+        "name": "Trader Joe",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Standard.png",
+        "id": "standard",
+        "name": "Standard",
+        "supportedChains": ["astar-shiden"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Katana.png",
+        "id": "katana",
+        "name": "Katana",
+        "supportedChains": ["axie-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Stellaswap.png",
+        "id": "stellaswap",
+        "name": "StellaSwap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Beamswap.png",
+        "id": "beamswap",
+        "name": "Beamswap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Empire.png",
+        "id": "empire",
+        "name": "Empire",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Moonlift.png",
+        "id": "moonlift",
+        "name": "MoonLift",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mimo.png",
+        "id": "mimo",
+        "name": "Mimo",
+        "supportedChains": ["iotex-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Claimswap.png",
+        "id": "claimswap",
+        "name": "Claimswap",
+        "supportedChains": ["klaytn-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/WannaSwap.png",
+        "id": "wannaswap",
+        "name": "Wannaswap",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trisolaris.png",
+        "id": "trisolaris",
+        "name": "Trisolaris",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Diffusion.png",
+        "id": "diffusion",
+        "name": "Diffusion",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Cronus.png",
+        "id": "cronus",
+        "name": "Cronus",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Evmoswap.png",
+        "id": "evmoswap",
+        "name": "EVMOSwap",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ArthSwap.png",
+        "id": "arthswap",
+        "name": "ArthSwap",
+        "supportedChains": ["astar-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mmf.png",
+        "id": "mmf",
+        "name": "Mad Meerkat Finance",
+        "supportedChains": ["cronos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/VVSFinancial.png",
+        "id": "vvs",
+        "name": "VVS Finance",
+        "supportedChains": ["cronos-mainnet"]
+      }
+    ],
+    "response": {
+      "status": 200,
+      "name": "SingleNetworkExchangeTokenResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/ExchangeVolumeWithVolumeAndLiquidityTimeseries"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "UniswapLikeVolumeChartWithQuote": {
+          "type": "object",
+          "properties": {
+            "dex_name": {
+              "type": "string"
+            },
+            "chain_id": {
+              "type": "string"
+            },
+            "dt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "exchange": {
+              "type": "string"
+            },
+            "sum_amount0in": {
+              "type": "number"
+            },
+            "sum_amount0out": {
+              "type": "number"
+            },
+            "sum_amount1in": {
+              "type": "number"
+            },
+            "sum_amount1out": {
+              "type": "number"
+            },
+            "volume_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "token0_quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "token1_quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "swap_count_24": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "UniswapLikePriceChartWithQuote": {
+          "type": "object",
+          "properties": {
+            "dex_name": {
+              "type": "string"
+            },
+            "chain_id": {
+              "type": "string"
+            },
+            "dt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "exchange": {
+              "type": "string"
+            },
+            "price_of_token0_in_token1": {
+              "type": "number",
+              "format": "float"
+            },
+            "price_of_token0_in_token1_description": {
+              "type": "string"
+            },
+            "price_of_token1_in_token0": {
+              "type": "number",
+              "format": "float"
+            },
+            "price_of_token1_in_token0_description": {
+              "type": "string"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "price_of_token0_in_quote_currency": {
+              "type": "number",
+              "format": "float"
+            },
+            "price_of_token1_in_quote_currency": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        "UniswapLikeLiquidityChartWithQuote": {
+          "type": "object",
+          "properties": {
+            "dex_name": {
+              "type": "string"
+            },
+            "chain_id": {
+              "type": "string"
+            },
+            "dt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "exchange": {
+              "type": "string"
+            },
+            "r0_c": {
+              "type": "number"
+            },
+            "r1_c": {
+              "type": "number"
+            },
+            "liquidity_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "token0_quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "token1_quote_rate": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        "SingleNetworkExchangeTokenResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/ExchangeVolumeWithVolumeAndLiquidityTimeseries"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "ExchangeVolumeWithVolumeAndLiquidityTimeseries": {
+          "type": "object",
+          "properties": {
+            "dex_name": {
+              "type": "string"
+            },
+            "chain_id": {
+              "type": "string"
+            },
+            "exchange": {
+              "type": "string"
+            },
+            "swap_count_24h": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "total_liquidity_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "volume_24h_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "fee_24h_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "volume_7d_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "annualized_fee": {
+              "type": "number",
+              "format": "float"
+            },
+            "total_supply": {
+              "type": "integer"
+            },
+            "quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "block_height": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "token_0": {
+              "$ref": "#/components/schemas/TokenV2"
+            },
+            "token_1": {
+              "$ref": "#/components/schemas/TokenV2"
+            },
+            "token0_reserve_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "token1_reserve_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "volume_timeseries_7d": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikeVolumeChartWithQuote"
+                }
+              }
+            },
+            "volume_timeseries_30d": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikeVolumeChartWithQuote"
+                }
+              }
+            },
+            "liquidity_timeseries_7d": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikeLiquidityChartWithQuote"
+                }
+              }
+            },
+            "liquidity_timeseries_30d": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikeLiquidityChartWithQuote"
+                }
+              }
+            },
+            "price_timeseries_7d": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikePriceChartWithQuote"
+                }
+              }
+            },
+            "price_timeseries_30d": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikePriceChartWithQuote"
+                }
+              }
+            }
+          }
+        },
+        "TokenV2": {
+          "type": "object",
+          "properties": {
+            "contract_address": {
+              "type": "string"
+            },
+            "contract_name": {
+              "type": "string"
+            },
+            "volume_in_24h": {
+              "type": "number"
+            },
+            "volume_out_24h": {
+              "type": "number"
+            },
+            "quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "reserve": {
+              "type": "integer"
+            },
+            "logo_url": {
+              "type": "string"
+            },
+            "contract_ticker_symbol": {
+              "type": "string"
+            },
+            "contract_decimals": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "volume_in_7d": {
+              "type": "number"
+            },
+            "volume_out_7d": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get NFT transactions for contract",
+    "description": "Given `:chain_id`, `:contract_address` and `:token_id`, return a list of transactions.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/tokens/:contract_address/nft_transactions/:token_id/",
+    "released_at": "",
+    "order": 13,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "contract_address",
+        "description": "Smart contract address.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "token_id",
+        "description": "The token ID",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Get list of NFT transactions given Meme Ltd token ID",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "contract_address",
+            "value": "0xe4605d46fd0b3f8329d936a8b258d69276cba264"
+          },
+          {
+            "name": "token_id",
+            "value": "123"
+          }
+        ]
+      }
+    ],
+    "notes": [
+      {
+        "title": "sender_logo_url field",
+        "description": "sender_logo_url may reference to a not found resource (return status 404)."
+      }
+    ],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "NftTransactionsResponseType",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/NftTransactionsResponse"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "DecodedParamItem": {
+          "type": "object",
+          "description": "The parameters of the decoded item.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the parameter."
+            },
+            "type": {
+              "type": "string",
+              "description": "The type of the parameter."
+            },
+            "indexed": {
+              "type": "boolean",
+              "description": "The index of the parameter."
+            },
+            "decoded": {
+              "type": "boolean",
+              "description": "The decoded value of the parameter."
+            },
+            "value": {
+              "type": "object",
+              "description": "The value of the parameter."
+            }
+          }
+        },
+        "DecodedItem": {
+          "type": "object",
+          "description": "The decoded item.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the decoded item."
+            },
+            "signature": {
+              "type": "string",
+              "description": "The signature of the decoded item."
+            },
+            "params": {
+              "type": "array",
+              "description": "The parameters of the decoded item.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/DecodedParamItem"
+                }
+              }
+            }
+          }
+        },
+        "LogEventItem": {
+          "type": "object",
+          "description": "The log events.",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int64"
+            },
+            "tx_offset": {
+              "type": "integer",
+              "description": "The transaction offset.",
+              "format": "int64"
+            },
+            "log_offset": {
+              "type": "integer",
+              "description": "The log offset.",
+              "format": "int64"
+            },
+            "tx_hash": {
+              "type": "string",
+              "description": "The transaction hash."
+            },
+            "raw_log_topics": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "sender_contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "sender_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "sender_contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "sender_address": {
+              "type": "string",
+              "description": "The address of the sender."
+            },
+            "sender_address_label": {
+              "type": "string",
+              "description": "The label of the sender address."
+            },
+            "sender_logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "raw_log_data": {
+              "type": "string",
+              "description": "The log events in raw."
+            },
+            "decoded": {
+              "$ref": "#/components/schemas/DecodedItem"
+            }
+          }
+        },
+        "NftTransactionsResponse": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "supports_erc": {
+              "type": "array",
+              "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+              "items": {
+                "items": {
+                  "type": "string",
+                  "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+                }
+              }
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "type": {
+              "type": "string",
+              "description": "One of `cryptocurrency`, `stablecoin`, `nft` or `dust`."
+            },
+            "nft_transactions": {
+              "type": "array",
+              "description": "The nft transactions.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/BlockTransactionWithLogEvents"
+                }
+              }
+            }
+          }
+        },
+        "BlockTransactionWithLogEvents": {
+          "type": "object",
+          "description": "The nft transactions.",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "description": "The signed time of the block.",
+              "format": "date-time"
+            },
+            "block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int32"
+            },
+            "tx_hash": {
+              "type": "string",
+              "description": "The transaction hash."
+            },
+            "tx_offset": {
+              "type": "integer",
+              "description": "The transaction offset.",
+              "format": "int32"
+            },
+            "successful": {
+              "type": "boolean",
+              "description": "The transaction status."
+            },
+            "from_address": {
+              "type": "string",
+              "description": "The address where the transaction is from."
+            },
+            "from_address_label": {
+              "type": "string",
+              "description": "The label of `from` address."
+            },
+            "to_address": {
+              "type": "string",
+              "description": "The address where the transaction is to."
+            },
+            "to_address_label": {
+              "type": "string",
+              "description": "The label of `to` address."
+            },
+            "value": {
+              "type": "number",
+              "description": "The value attached to this tx."
+            },
+            "value_quote": {
+              "type": "number",
+              "description": "The value attached in `quote-currency` to this tx.",
+              "format": "double"
+            },
+            "gas_offered": {
+              "type": "integer",
+              "description": "The gas offered for this tx.",
+              "format": "int64"
+            },
+            "gas_spent": {
+              "type": "integer",
+              "description": "The gas spent for this tx.",
+              "format": "int64"
+            },
+            "gas_price": {
+              "type": "integer",
+              "description": "The gas price at the time of this tx.",
+              "format": "int64"
+            },
+            "fees_paid": {
+              "type": "number",
+              "description": "The total transaction fees paid for this tx."
+            },
+            "gas_quote": {
+              "type": "number",
+              "description": "The gas spent in `quote-currency` denomination.",
+              "format": "double"
+            },
+            "gas_quote_rate": {
+              "type": "number",
+              "description": "The gas exchange rate at the time of Tx in `quote_currency`.",
+              "format": "double"
+            },
+            "log_events": {
+              "type": "array",
+              "description": "The log events.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/LogEventItem"
+                }
+              }
+            }
+          }
+        },
+        "NftTransactionsResponseType": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/NftTransactionsResponse"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K transactions for account address",
+    "description": "Given `:chain_id`, `:dexname` and `:address`, return transactions for account address for a specific DEX.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/:chain_id/xy=k/:dexname/address/:address/transactions/",
+    "released_at": "",
+    "order": 13,
+    "realTime": false,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "dexname",
+        "description": "One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": [
+          "uniswap_v2",
+          "sushiswap",
+          "pancakeswap_v2",
+          "quickswap",
+          "pangolin",
+          "spiritswap",
+          "spookyswap",
+          "traderjoe",
+          "standard",
+          "apeswap_v2",
+          "katana",
+          "stellaswap",
+          "beamswap"
+        ]
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/uniswap.png",
+        "id": "uniswapv2",
+        "name": "Uniswap V2",
+        "supportedChains": ["ethereum-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/sushi.png",
+        "id": "sushiswap",
+        "name": "SushiSwap",
+        "supportedChains": [
+          "ethereum-mainnet",
+          "matic-mainnet",
+          "fantom-mainnet",
+          "fantom-testnet",
+          "avalanche-testnet",
+          "avalanche-mainnet",
+          "bsc-mainnet",
+          "matic-mumbai"
+        ]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pancakeswap.png",
+        "id": "pancakeswap",
+        "name": "PancakeSwap",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/spiritswap.png",
+        "id": "spiritswap",
+        "name": "SpiritSwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Spookyswap.png",
+        "id": "spookyswap",
+        "name": "SpookySwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Quickswap.png",
+        "id": "quickswap",
+        "name": "QuickSwap",
+        "supportedChains": ["matic-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ApeSwap.png",
+        "id": "apeswapv2",
+        "name": "ApeSwap V2",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pangolin.png",
+        "id": "pangolin",
+        "name": "Pangolin",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trader Joe.png",
+        "id": "traderjoe",
+        "name": "Trader Joe",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Standard.png",
+        "id": "standard",
+        "name": "Standard",
+        "supportedChains": ["astar-shiden"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Katana.png",
+        "id": "katana",
+        "name": "Katana",
+        "supportedChains": ["axie-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Stellaswap.png",
+        "id": "stellaswap",
+        "name": "StellaSwap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Beamswap.png",
+        "id": "beamswap",
+        "name": "Beamswap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Empire.png",
+        "id": "empire",
+        "name": "Empire",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Moonlift.png",
+        "id": "moonlift",
+        "name": "MoonLift",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mimo.png",
+        "id": "mimo",
+        "name": "Mimo",
+        "supportedChains": ["iotex-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Claimswap.png",
+        "id": "claimswap",
+        "name": "Claimswap",
+        "supportedChains": ["klaytn-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/WannaSwap.png",
+        "id": "wannaswap",
+        "name": "Wannaswap",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trisolaris.png",
+        "id": "trisolaris",
+        "name": "Trisolaris",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Diffusion.png",
+        "id": "diffusion",
+        "name": "Diffusion",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Cronus.png",
+        "id": "cronus",
+        "name": "Cronus",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Evmoswap.png",
+        "id": "evmoswap",
+        "name": "EVMOSwap",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ArthSwap.png",
+        "id": "arthswap",
+        "name": "ArthSwap",
+        "supportedChains": ["astar-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mmf.png",
+        "id": "mmf",
+        "name": "Mad Meerkat Finance",
+        "supportedChains": ["cronos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/VVSFinancial.png",
+        "id": "vvs",
+        "name": "VVS Finance",
+        "supportedChains": ["cronos-mainnet"]
+      }
+    ],
+    "response": {
+      "status": 200,
+      "name": "AccountAddressTransactionsResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/ExchangeTransaction"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "ContractMetadata": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "supports_erc": {
+              "type": "array",
+              "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+              "items": {
+                "items": {
+                  "type": "string",
+                  "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+                }
+              }
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            }
+          }
+        },
+        "ExchangeTransaction": {
+          "type": "object",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "tx_hash": {
+              "type": "string"
+            },
+            "act": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "amount_0": {
+              "type": "number"
+            },
+            "amount_1": {
+              "type": "number"
+            },
+            "amount_0_in": {
+              "type": "number"
+            },
+            "amount_1_in": {
+              "type": "number"
+            },
+            "amount_0_out": {
+              "type": "number"
+            },
+            "amount_1_out": {
+              "type": "number"
+            },
+            "to_address": {
+              "type": "string"
+            },
+            "from_address": {
+              "type": "string"
+            },
+            "sender_address": {
+              "type": "string"
+            },
+            "total_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "token_0": {
+              "$ref": "#/components/schemas/ContractMetadata"
+            },
+            "token_1": {
+              "$ref": "#/components/schemas/ContractMetadata"
+            },
+            "token_0_quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "token_1_quote_rate": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        "AccountAddressTransactionsResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/ExchangeTransaction"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get NFT external metadata for contract",
+    "description": "Given `:chain_id`, `:contract_address` and `:token_id`, fetch and return the external metadata. Both ERC721 as well as ERC1155 standards are supported.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/:chain_id/tokens/:contract_address/nft_metadata/:token_id/",
+    "released_at": "",
+    "order": 14,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "contract_address",
+        "description": "Smart contract address.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "token_id",
+        "description": "The token ID",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "format",
+        "description": "If `format=csv`, return a flat CSV instead of JSON responses.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [
+      {
+        "description": "Get NFT external metadata given Meme Ltd token ID",
+        "params": [
+          {
+            "name": "chain_id",
+            "value": "1"
+          },
+          {
+            "name": "contract_address",
+            "value": "0xe4605d46fd0b3f8329d936a8b258d69276cba264"
+          },
+          {
+            "name": "token_id",
+            "value": "123"
+          }
+        ]
+      }
+    ],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "NFTMetaDataRsponseType",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/WalletBalanceItem"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "NFTMetaDataRsponseType": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/WalletBalanceItem"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "INFTMetadata": {
+          "type": "object",
+          "description": "Array of NFTs that are held under this contract."
+        },
+        "WalletBalanceItem": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "supports_erc": {
+              "type": "array",
+              "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+              "items": {
+                "items": {
+                  "type": "string",
+                  "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+                }
+              }
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            },
+            "last_transferred_at": {
+              "type": "string",
+              "description": "Last transferred date for a wallet",
+              "format": "date-time"
+            },
+            "native_token": {
+              "type": "boolean",
+              "description": "Indicates if a token is the chain's native gas token, eg: ETH on Ethereum."
+            },
+            "type": {
+              "type": "string",
+              "description": "One of `cryptocurrency`, `stablecoin`, `nft` or `dust`."
+            },
+            "balance": {
+              "type": "integer",
+              "description": "The asset balance. Use `contract_decimals` to scale this balance for display purposes."
+            },
+            "balance_24h": {
+              "type": "integer",
+              "description": "The asset balance 24 hours ago."
+            },
+            "quote_rate": {
+              "type": "number",
+              "description": "The current spot exchange rate in `quote-currency`.",
+              "format": "float"
+            },
+            "quote_rate_24h": {
+              "type": "number",
+              "description": "The spot exchange rate in `quote-currency` as of 24 hours ago.",
+              "format": "float"
+            },
+            "quote": {
+              "type": "number",
+              "description": "The current balance converted to fiat in `quote-currency`.",
+              "format": "float"
+            },
+            "quote_24h": {
+              "type": "number",
+              "description": "The current balance converted to fiat in `quote-currency` as of 24 hours ago.",
+              "format": "float"
+            },
+            "nft_data": {
+              "type": "array",
+              "description": "Array of NFTs that are held under this contract.",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/INFTMetadata"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K transactions for token address",
+    "description": "Given `:chain_id`, `:dexname` and `:token_address`, return transactions for token address for a specific DEX.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/:chain_id/xy=k/:dexname/tokens/address/:token_address/transactions/",
+    "released_at": "",
+    "order": 14,
+    "realTime": false,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "token_address",
+        "description": "token address",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "dexname",
+        "description": "One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": [
+          "uniswap_v2",
+          "sushiswap",
+          "pancakeswap_v2",
+          "quickswap",
+          "pangolin",
+          "spiritswap",
+          "spookyswap",
+          "traderjoe",
+          "standard",
+          "apeswap_v2",
+          "katana",
+          "stellaswap",
+          "beamswap"
+        ]
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/uniswap.png",
+        "id": "uniswapv2",
+        "name": "Uniswap V2",
+        "supportedChains": ["ethereum-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/sushi.png",
+        "id": "sushiswap",
+        "name": "SushiSwap",
+        "supportedChains": [
+          "ethereum-mainnet",
+          "matic-mainnet",
+          "fantom-mainnet",
+          "fantom-testnet",
+          "avalanche-testnet",
+          "avalanche-mainnet",
+          "bsc-mainnet",
+          "matic-mumbai"
+        ]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pancakeswap.png",
+        "id": "pancakeswap",
+        "name": "PancakeSwap",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/spiritswap.png",
+        "id": "spiritswap",
+        "name": "SpiritSwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Spookyswap.png",
+        "id": "spookyswap",
+        "name": "SpookySwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Quickswap.png",
+        "id": "quickswap",
+        "name": "QuickSwap",
+        "supportedChains": ["matic-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ApeSwap.png",
+        "id": "apeswapv2",
+        "name": "ApeSwap V2",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pangolin.png",
+        "id": "pangolin",
+        "name": "Pangolin",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trader Joe.png",
+        "id": "traderjoe",
+        "name": "Trader Joe",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Standard.png",
+        "id": "standard",
+        "name": "Standard",
+        "supportedChains": ["astar-shiden"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Katana.png",
+        "id": "katana",
+        "name": "Katana",
+        "supportedChains": ["axie-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Stellaswap.png",
+        "id": "stellaswap",
+        "name": "StellaSwap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Beamswap.png",
+        "id": "beamswap",
+        "name": "Beamswap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Empire.png",
+        "id": "empire",
+        "name": "Empire",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Moonlift.png",
+        "id": "moonlift",
+        "name": "MoonLift",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mimo.png",
+        "id": "mimo",
+        "name": "Mimo",
+        "supportedChains": ["iotex-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Claimswap.png",
+        "id": "claimswap",
+        "name": "Claimswap",
+        "supportedChains": ["klaytn-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/WannaSwap.png",
+        "id": "wannaswap",
+        "name": "Wannaswap",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trisolaris.png",
+        "id": "trisolaris",
+        "name": "Trisolaris",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Diffusion.png",
+        "id": "diffusion",
+        "name": "Diffusion",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Cronus.png",
+        "id": "cronus",
+        "name": "Cronus",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Evmoswap.png",
+        "id": "evmoswap",
+        "name": "EVMOSwap",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ArthSwap.png",
+        "id": "arthswap",
+        "name": "ArthSwap",
+        "supportedChains": ["astar-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mmf.png",
+        "id": "mmf",
+        "name": "Mad Meerkat Finance",
+        "supportedChains": ["cronos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/VVSFinancial.png",
+        "id": "vvs",
+        "name": "VVS Finance",
+        "supportedChains": ["cronos-mainnet"]
+      }
+    ],
+    "response": {
+      "status": 200,
+      "name": "TokenAddressTransactionsResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/ExchangeTransaction"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "ContractMetadata": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "supports_erc": {
+              "type": "array",
+              "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+              "items": {
+                "items": {
+                  "type": "string",
+                  "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+                }
+              }
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            }
+          }
+        },
+        "ExchangeTransaction": {
+          "type": "object",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "tx_hash": {
+              "type": "string"
+            },
+            "act": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "amount_0": {
+              "type": "number"
+            },
+            "amount_1": {
+              "type": "number"
+            },
+            "amount_0_in": {
+              "type": "number"
+            },
+            "amount_1_in": {
+              "type": "number"
+            },
+            "amount_0_out": {
+              "type": "number"
+            },
+            "amount_1_out": {
+              "type": "number"
+            },
+            "to_address": {
+              "type": "string"
+            },
+            "from_address": {
+              "type": "string"
+            },
+            "sender_address": {
+              "type": "string"
+            },
+            "total_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "token_0": {
+              "$ref": "#/components/schemas/ContractMetadata"
+            },
+            "token_1": {
+              "$ref": "#/components/schemas/ContractMetadata"
+            },
+            "token_0_quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "token_1_quote_rate": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        "TokenAddressTransactionsResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/ExchangeTransaction"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K transactions for exchange",
+    "description": "Given `:chain_id`, `:dexname` and `:address`, return transactions for exchange for a specific DEX.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/:chain_id/xy=k/:dexname/pools/address/:address/transactions/",
+    "released_at": "",
+    "order": 15,
+    "realTime": false,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "address",
+        "description": "Passing in an `ENS` resolves automatically.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "dexname",
+        "description": "One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": [
+          "uniswap_v2",
+          "sushiswap",
+          "pancakeswap_v2",
+          "quickswap",
+          "pangolin",
+          "spiritswap",
+          "spookyswap",
+          "traderjoe",
+          "standard",
+          "apeswap_v2",
+          "katana",
+          "stellaswap",
+          "beamswap"
+        ]
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/uniswap.png",
+        "id": "uniswapv2",
+        "name": "Uniswap V2",
+        "supportedChains": ["ethereum-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/sushi.png",
+        "id": "sushiswap",
+        "name": "SushiSwap",
+        "supportedChains": [
+          "ethereum-mainnet",
+          "matic-mainnet",
+          "fantom-mainnet",
+          "fantom-testnet",
+          "avalanche-testnet",
+          "avalanche-mainnet",
+          "bsc-mainnet",
+          "matic-mumbai"
+        ]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pancakeswap.png",
+        "id": "pancakeswap",
+        "name": "PancakeSwap",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/spiritswap.png",
+        "id": "spiritswap",
+        "name": "SpiritSwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Spookyswap.png",
+        "id": "spookyswap",
+        "name": "SpookySwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Quickswap.png",
+        "id": "quickswap",
+        "name": "QuickSwap",
+        "supportedChains": ["matic-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ApeSwap.png",
+        "id": "apeswapv2",
+        "name": "ApeSwap V2",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pangolin.png",
+        "id": "pangolin",
+        "name": "Pangolin",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trader Joe.png",
+        "id": "traderjoe",
+        "name": "Trader Joe",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Standard.png",
+        "id": "standard",
+        "name": "Standard",
+        "supportedChains": ["astar-shiden"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Katana.png",
+        "id": "katana",
+        "name": "Katana",
+        "supportedChains": ["axie-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Stellaswap.png",
+        "id": "stellaswap",
+        "name": "StellaSwap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Beamswap.png",
+        "id": "beamswap",
+        "name": "Beamswap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Empire.png",
+        "id": "empire",
+        "name": "Empire",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Moonlift.png",
+        "id": "moonlift",
+        "name": "MoonLift",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mimo.png",
+        "id": "mimo",
+        "name": "Mimo",
+        "supportedChains": ["iotex-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Claimswap.png",
+        "id": "claimswap",
+        "name": "Claimswap",
+        "supportedChains": ["klaytn-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/WannaSwap.png",
+        "id": "wannaswap",
+        "name": "Wannaswap",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trisolaris.png",
+        "id": "trisolaris",
+        "name": "Trisolaris",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Diffusion.png",
+        "id": "diffusion",
+        "name": "Diffusion",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Cronus.png",
+        "id": "cronus",
+        "name": "Cronus",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Evmoswap.png",
+        "id": "evmoswap",
+        "name": "EVMOSwap",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ArthSwap.png",
+        "id": "arthswap",
+        "name": "ArthSwap",
+        "supportedChains": ["astar-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mmf.png",
+        "id": "mmf",
+        "name": "Mad Meerkat Finance",
+        "supportedChains": ["cronos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/VVSFinancial.png",
+        "id": "vvs",
+        "name": "VVS Finance",
+        "supportedChains": ["cronos-mainnet"]
+      }
+    ],
+    "response": {
+      "status": 200,
+      "name": "ExchangeTransactionsResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/ExchangeTransaction"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "ContractMetadata": {
+          "type": "object",
+          "properties": {
+            "contract_decimals": {
+              "type": "integer",
+              "description": "Smart contract decimals.",
+              "format": "int32"
+            },
+            "contract_name": {
+              "type": "string",
+              "description": "Smart contract name."
+            },
+            "contract_ticker_symbol": {
+              "type": "string",
+              "description": "Smart contract ticker symbol."
+            },
+            "contract_address": {
+              "type": "string",
+              "description": "Smart contract address."
+            },
+            "supports_erc": {
+              "type": "array",
+              "description": "The standard interface(s) supported for this token, eg: `ERC-20`.",
+              "items": {
+                "items": {
+                  "type": "string",
+                  "description": "The standard interface(s) supported for this token, eg: `ERC-20`."
+                }
+              }
+            },
+            "logo_url": {
+              "type": "string",
+              "description": "Smart contract URL."
+            }
+          }
+        },
+        "ExchangeTransaction": {
+          "type": "object",
+          "properties": {
+            "block_signed_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "tx_hash": {
+              "type": "string"
+            },
+            "act": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "amount_0": {
+              "type": "number"
+            },
+            "amount_1": {
+              "type": "number"
+            },
+            "amount_0_in": {
+              "type": "number"
+            },
+            "amount_1_in": {
+              "type": "number"
+            },
+            "amount_0_out": {
+              "type": "number"
+            },
+            "amount_1_out": {
+              "type": "number"
+            },
+            "to_address": {
+              "type": "string"
+            },
+            "from_address": {
+              "type": "string"
+            },
+            "sender_address": {
+              "type": "string"
+            },
+            "total_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "token_0": {
+              "$ref": "#/components/schemas/ContractMetadata"
+            },
+            "token_1": {
+              "$ref": "#/components/schemas/ContractMetadata"
+            },
+            "token_0_quote_rate": {
+              "type": "number",
+              "format": "float"
+            },
+            "token_1_quote_rate": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        "ExchangeTransactionsResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/ExchangeTransaction"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K ecosystem chart data",
+    "description": "Given `:chain_id` and `:dexname`, return ecosystem chart data for a specific DEX.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/:chain_id/xy=k/:dexname/ecosystem/",
+    "released_at": "",
+    "order": 16,
+    "realTime": false,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "dexname",
+        "description": "One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": [
+          "uniswap_v2",
+          "sushiswap",
+          "pancakeswap_v2",
+          "quickswap",
+          "pangolin",
+          "spiritswap",
+          "spookyswap",
+          "traderjoe",
+          "standard",
+          "apeswap_v2",
+          "katana",
+          "stellaswap",
+          "beamswap"
+        ]
+      },
+      {
+        "name": "quote-currency",
+        "description": "The requested fiat currency.",
+        "type": "string",
+        "required": false,
+        "primer": false,
+        "global": true,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/uniswap.png",
+        "id": "uniswapv2",
+        "name": "Uniswap V2",
+        "supportedChains": ["ethereum-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/sushi.png",
+        "id": "sushiswap",
+        "name": "SushiSwap",
+        "supportedChains": [
+          "ethereum-mainnet",
+          "matic-mainnet",
+          "fantom-mainnet",
+          "fantom-testnet",
+          "avalanche-testnet",
+          "avalanche-mainnet",
+          "bsc-mainnet",
+          "matic-mumbai"
+        ]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pancakeswap.png",
+        "id": "pancakeswap",
+        "name": "PancakeSwap",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/spiritswap.png",
+        "id": "spiritswap",
+        "name": "SpiritSwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Spookyswap.png",
+        "id": "spookyswap",
+        "name": "SpookySwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Quickswap.png",
+        "id": "quickswap",
+        "name": "QuickSwap",
+        "supportedChains": ["matic-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ApeSwap.png",
+        "id": "apeswapv2",
+        "name": "ApeSwap V2",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pangolin.png",
+        "id": "pangolin",
+        "name": "Pangolin",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trader Joe.png",
+        "id": "traderjoe",
+        "name": "Trader Joe",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Standard.png",
+        "id": "standard",
+        "name": "Standard",
+        "supportedChains": ["astar-shiden"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Katana.png",
+        "id": "katana",
+        "name": "Katana",
+        "supportedChains": ["axie-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Stellaswap.png",
+        "id": "stellaswap",
+        "name": "StellaSwap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Beamswap.png",
+        "id": "beamswap",
+        "name": "Beamswap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Empire.png",
+        "id": "empire",
+        "name": "Empire",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Moonlift.png",
+        "id": "moonlift",
+        "name": "MoonLift",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mimo.png",
+        "id": "mimo",
+        "name": "Mimo",
+        "supportedChains": ["iotex-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Claimswap.png",
+        "id": "claimswap",
+        "name": "Claimswap",
+        "supportedChains": ["klaytn-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/WannaSwap.png",
+        "id": "wannaswap",
+        "name": "Wannaswap",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trisolaris.png",
+        "id": "trisolaris",
+        "name": "Trisolaris",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Diffusion.png",
+        "id": "diffusion",
+        "name": "Diffusion",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Cronus.png",
+        "id": "cronus",
+        "name": "Cronus",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Evmoswap.png",
+        "id": "evmoswap",
+        "name": "EVMOSwap",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ArthSwap.png",
+        "id": "arthswap",
+        "name": "ArthSwap",
+        "supportedChains": ["astar-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mmf.png",
+        "id": "mmf",
+        "name": "Mad Meerkat Finance",
+        "supportedChains": ["cronos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/VVSFinancial.png",
+        "id": "vvs",
+        "name": "VVS Finance",
+        "supportedChains": ["cronos-mainnet"]
+      }
+    ],
+    "response": {
+      "status": 200,
+      "name": "EcosystemResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/UniswapLikeEcosystemCharts"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "EcosystemResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikeEcosystemCharts"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "UniswapLikeEcosystemCharts": {
+          "type": "object",
+          "properties": {
+            "dex_name": {
+              "type": "string"
+            },
+            "chain_id": {
+              "type": "string"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "gas_token_price_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "total_swaps_24h": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "total_active_pairs_7d": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "total_fees_24h": {
+              "type": "number",
+              "format": "float"
+            },
+            "volume_chart_7d": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikeVolumeEcosystemChart"
+                }
+              }
+            },
+            "volume_chart_30d": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikeVolumeEcosystemChart"
+                }
+              }
+            },
+            "liquidity_chart_7d": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikeLiquidityEcosystemChart"
+                }
+              }
+            },
+            "liquidity_chart_30d": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/UniswapLikeLiquidityEcosystemChart"
+                }
+              }
+            }
+          }
+        },
+        "UniswapLikeVolumeEcosystemChart": {
+          "type": "object",
+          "properties": {
+            "dex_name": {
+              "type": "string"
+            },
+            "chain_id": {
+              "type": "string"
+            },
+            "dt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "volume_quote": {
+              "type": "number",
+              "format": "float"
+            },
+            "swap_count_24": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "UniswapLikeLiquidityEcosystemChart": {
+          "type": "object",
+          "properties": {
+            "dex_name": {
+              "type": "string"
+            },
+            "chain_id": {
+              "type": "string"
+            },
+            "dt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "quote_currency": {
+              "type": "string"
+            },
+            "liquidity_quote": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get XY=K health data",
+    "description": "Given `:chain_id` and `:dexname`, return last synced block height data and latest block height for a specific DEX.",
+    "classType": "Class B",
+    "classSubType": "xy=k",
+    "classSubTypeDescription": "xy=k is a generalized Uniswap-like endpoints for exchanges on various chains.",
+    "path": "/v1/:chain_id/xy=k/:dexname/health/",
+    "released_at": "",
+    "order": 17,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [
+      {
+        "name": "chain_id",
+        "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": true,
+        "pathParam": true,
+        "choices": []
+      },
+      {
+        "name": "dexname",
+        "description": "One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.",
+        "type": "string",
+        "required": true,
+        "primer": false,
+        "global": false,
+        "pathParam": true,
+        "choices": [
+          "uniswap_v2",
+          "sushiswap",
+          "pancakeswap_v2",
+          "quickswap",
+          "pangolin",
+          "spiritswap",
+          "spookyswap",
+          "traderjoe",
+          "standard",
+          "apeswap_v2",
+          "katana",
+          "stellaswap",
+          "beamswap"
+        ]
+      },
+      {
+        "name": "page-number",
+        "description": "The specific page to be returned.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      },
+      {
+        "name": "page-size",
+        "description": "The number of results per page.",
+        "type": "integer",
+        "required": false,
+        "primer": false,
+        "global": false,
+        "pathParam": false,
+        "choices": []
+      }
+    ],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/uniswap.png",
+        "id": "uniswapv2",
+        "name": "Uniswap V2",
+        "supportedChains": ["ethereum-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/sushi.png",
+        "id": "sushiswap",
+        "name": "SushiSwap",
+        "supportedChains": [
+          "ethereum-mainnet",
+          "matic-mainnet",
+          "fantom-mainnet",
+          "fantom-testnet",
+          "avalanche-testnet",
+          "avalanche-mainnet",
+          "bsc-mainnet",
+          "matic-mumbai"
+        ]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pancakeswap.png",
+        "id": "pancakeswap",
+        "name": "PancakeSwap",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/spiritswap.png",
+        "id": "spiritswap",
+        "name": "SpiritSwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Spookyswap.png",
+        "id": "spookyswap",
+        "name": "SpookySwap",
+        "supportedChains": ["fantom-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Quickswap.png",
+        "id": "quickswap",
+        "name": "QuickSwap",
+        "supportedChains": ["matic-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ApeSwap.png",
+        "id": "apeswapv2",
+        "name": "ApeSwap V2",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Pangolin.png",
+        "id": "pangolin",
+        "name": "Pangolin",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trader Joe.png",
+        "id": "traderjoe",
+        "name": "Trader Joe",
+        "supportedChains": ["avalanche-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Standard.png",
+        "id": "standard",
+        "name": "Standard",
+        "supportedChains": ["astar-shiden"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Katana.png",
+        "id": "katana",
+        "name": "Katana",
+        "supportedChains": ["axie-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Stellaswap.png",
+        "id": "stellaswap",
+        "name": "StellaSwap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Beamswap.png",
+        "id": "beamswap",
+        "name": "Beamswap",
+        "supportedChains": ["moonbeam-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Empire.png",
+        "id": "empire",
+        "name": "Empire",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Moonlift.png",
+        "id": "moonlift",
+        "name": "MoonLift",
+        "supportedChains": ["bsc-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mimo.png",
+        "id": "mimo",
+        "name": "Mimo",
+        "supportedChains": ["iotex-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Claimswap.png",
+        "id": "claimswap",
+        "name": "Claimswap",
+        "supportedChains": ["klaytn-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/WannaSwap.png",
+        "id": "wannaswap",
+        "name": "Wannaswap",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Trisolaris.png",
+        "id": "trisolaris",
+        "name": "Trisolaris",
+        "supportedChains": ["aurora-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Diffusion.png",
+        "id": "diffusion",
+        "name": "Diffusion",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Cronus.png",
+        "id": "cronus",
+        "name": "Cronus",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Evmoswap.png",
+        "id": "evmoswap",
+        "name": "EVMOSwap",
+        "supportedChains": ["evmos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/ArthSwap.png",
+        "id": "arthswap",
+        "name": "ArthSwap",
+        "supportedChains": ["astar-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/Mmf.png",
+        "id": "mmf",
+        "name": "Mad Meerkat Finance",
+        "supportedChains": ["cronos-mainnet"]
+      },
+      {
+        "logoURL": "https://www.covalenthq.com/static/images/dex-logos/VVSFinancial.png",
+        "id": "vvs",
+        "name": "VVS Finance",
+        "supportedChains": ["cronos-mainnet"]
+      }
+    ],
+    "response": {
+      "status": 200,
+      "name": "HealthDataResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/HealthData"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "HealthData": {
+          "type": "object",
+          "properties": {
+            "synced_block_height": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "synced_block_signed_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "latest_block_height": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "latest_block_signed_at": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "HealthDataResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/HealthData"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get all chains",
+    "description": "Returns a list of all chains.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/chains/",
+    "released_at": "",
+    "order": 18,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "AllChainInfoResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/GenericChainInfoDisplay"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "GenericChainInfoDisplay": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of chain"
+            },
+            "chain_id": {
+              "type": "string",
+              "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet."
+            },
+            "is_testnet": {
+              "type": "boolean"
+            },
+            "db_schema_name": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            },
+            "logo_url": {
+              "type": "string"
+            }
+          }
+        },
+        "AllChainInfoResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/GenericChainInfoDisplay"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "1",
+    "title": "Get all chain statuses",
+    "description": "Returns a list of all chain statuses.",
+    "classType": "Class A",
+    "classSubType": "",
+    "classSubTypeDescription": "",
+    "path": "/v1/chains/status/",
+    "released_at": "",
+    "order": 19,
+    "realTime": true,
+    "websocketSupport": false,
+    "isBeta": false,
+    "params": [],
+    "templates": [],
+    "notes": [],
+    "supportedProtocols": [],
+    "response": {
+      "status": 200,
+      "name": "ChainStatusResponse",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "updated_at": {
+            "type": "string",
+            "description": "The updated time.",
+            "format": "date-time"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/GenericChainInfoStatusDisplay"
+              }
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/AppliedPagination"
+          }
+        }
+      },
+      "components": {
+        "AppliedPagination": {
+          "type": "object",
+          "properties": {
+            "has_more": {
+              "type": "boolean",
+              "description": "`true` if we can  paginate to get more data."
+            },
+            "page_number": {
+              "type": "integer",
+              "description": "The specific page being returned.",
+              "format": "int32"
+            },
+            "page_size": {
+              "type": "integer",
+              "description": "The number of results per page.",
+              "format": "int32"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total number of entries.",
+              "format": "int32"
+            }
+          }
+        },
+        "ChainStatusResponse": {
+          "type": "object",
+          "properties": {
+            "updated_at": {
+              "type": "string",
+              "description": "The updated time.",
+              "format": "date-time"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "items": {
+                  "$ref": "#/components/schemas/GenericChainInfoStatusDisplay"
+                }
+              }
+            },
+            "pagination": {
+              "$ref": "#/components/schemas/AppliedPagination"
+            }
+          }
+        },
+        "GenericChainInfoStatusDisplay": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of chain"
+            },
+            "chain_id": {
+              "type": "string",
+              "description": "Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet."
+            },
+            "is_testnet": {
+              "type": "boolean"
+            },
+            "logo_url": {
+              "type": "string"
+            },
+            "synced_block_height": {
+              "type": "integer",
+              "description": "The height of the block.",
+              "format": "int32"
+            },
+            "synced_blocked_signed_at": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/covalent-sdk/scripts/updateSchema.ts
+++ b/packages/covalent-sdk/scripts/updateSchema.ts
@@ -1,0 +1,13 @@
+import path from 'path';
+import fs from 'fs';
+import axios from 'axios';
+
+async function updateSchema() {
+  const url = 'https://api.covalenthq.com/v1/openapiv2/';
+  const {data} = await axios.get(url);
+  if (!Array.isArray(data)) throw new Error(`Invalid response from ${url}`);
+  const schema = JSON.stringify(data, null, 4);
+  fs.writeFileSync(path.resolve(__dirname, 'schema.json'), schema);
+}
+
+updateSchema();

--- a/packages/covalent-sdk/src/index.ts
+++ b/packages/covalent-sdk/src/index.ts
@@ -1,0 +1,3862 @@
+// @ts-nocheck
+import axios, { Axios } from "axios"
+
+export namespace Covalent {
+    export enum ChainId {
+        ETHEREUM = 1,
+        ETHEREUM_KOVAN = 42,
+        POLYGON = 137,
+        POLYGON_MUMBAI = 80001,
+        AVALANCHE = 43114,
+        AVALANCHE_FUJI = 43113,
+        BSC = 56,
+        BSC_TESTNET = 97,
+        FANTOM = 250,
+        FANTOM_TESTNET = 4002,
+        RONIN = 2020,
+        MOONBEAM_TESTNET = 1287,
+        MOONBEAM_POLKADOT = 1284,
+        MOONRIVER_KUSAMA = 1285,
+        RSK_MAINNET = 30,
+        RSK_TESTNET = 31,
+        ARBITRUM_MAINNET = 42161,
+        ARBITRUM_TESTNET = 421611,
+        PALM_MAINNET = 11297108109,
+        PALM_TESTNET = 11297108099,
+        KLAYTN_MAINNET_CYPRESS = 8217,
+        HECO_MAINNET = 128,
+        HECO_TESTNET = 256,
+        POLYJUICE_TESTNET = 71393,
+        IOTEX_MAINNET = 4689,
+        IOTEX_TESTNET = 4690,
+        EVMOS_TESTNET = 9000,
+        ASTAR_MAINNET = 592,
+        ASTAR_TESTNET = 81,
+        SHIDEN = 336,
+        HARMONY_MAINNET = 1666600000,
+        AURORA_MAINNET = 1313161554,
+        CRONOS_MAINNET = 25,
+        SOLANA = 1399811149,
+    }
+
+    export class Client {
+        private http: Axios
+        constructor(private apiKey: string, private baseURL = "https://api.covalenthq.com") {
+            this.http = axios.create({
+                baseURL,
+                params: {
+                    key: apiKey,
+                },
+            })
+        }
+
+        /**
+         * Given `:chain_id` and `:contract_addresses`, return their historical prices. Can filter by date ranges and convert to `:quote_currency`. Only daily granularity is supported.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param contractAddresses - Passing in an `ENS` resolves automatically.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param from - The start day of the historical price range. (YYYY-MM-DD)
+         * @param to - The end day of the historical price range. (YYYY-MM-DD)
+         * @param pricesAtAsc - Sort the prices in chronological ascending order. By default, it's set to `false` and returns prices in chronological descending order.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         */
+        async getHistoricalTokenPrices({
+            chainId,
+            contractAddresses,
+            quoteCurrency,
+            from,
+            to,
+            pricesAtAsc,
+            format,
+            pageNumber,
+            pageSize,
+        }: {
+            chainId: ChainId
+            contractAddresses: string
+            quoteCurrency: string
+            from?: string
+            to?: string
+            pricesAtAsc?: string
+            format?: string
+            pageNumber?: number
+            pageSize?: number
+        }) {
+            const url = `/v1/pricing/historical_by_addresses_v2/${chainId}/${quoteCurrency}/${contractAddresses}/`
+            const { data } = await this.http.get<CovalentResponse<AddressWithHistoricalPricesItem>>(url, {
+                params: { from: from, to: to, "prices-at-asc": pricesAtAsc, format: format, "page-number": pageNumber, "page-size": pageSize },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and wallet `:address`, return current token balances along with their spot prices. This endpoint supports a variety of token standards like ERC20, ERC721 and ERC1155. As a special case, network native tokens like ETH on Ethereum are also returned even though it's not a token contract.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param nft - Set to `true` to return ERC721 and ERC1155 assets. Defaults to `false`.
+         * @param noNftFetch - Set to `true` to skip fetching NFT metadata, which can result in faster responses. Defaults to `false` and only applies when `nft=true`.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getTokenBalancesForAddress({
+            chainId,
+            address,
+            nft,
+            noNftFetch,
+            quoteCurrency,
+            format,
+        }: {
+            chainId: ChainId
+            address: string
+            nft?: boolean
+            noNftFetch?: boolean
+            quoteCurrency?: string
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/address/${address}/balances_v2/`
+            const { data } = await this.http.get<CovalentResponse<BalanceResponseType>>(url, {
+                params: { nft: nft, "no-nft-fetch": noNftFetch, "quote-currency": quoteCurrency, format: format },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and wallet `:address`, return wallet value for the last 30 days at 24 hour interval timestamps.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         * @param days - The range of the historical portfolio in days, defaults to 30 days (max days = 2000).
+         */
+        async getHistoricalPortfolioValueOverTime({
+            chainId,
+            address,
+            quoteCurrency,
+            format,
+            days,
+        }: {
+            chainId: ChainId
+            address: string
+            quoteCurrency?: string
+            format?: string
+            days?: string
+        }) {
+            const url = `/v1/${chainId}/address/${address}/portfolio_v2/`
+            const { data } = await this.http.get<CovalentResponse<HistoricalPortfolioResponse>>(url, {
+                params: { "quote-currency": quoteCurrency, format: format, days: days },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and wallet `:address`, return all transactions along with their decoded log events. This endpoint does a deep-crawl of the blockchain to retrieve all kinds of transactions that references the `:address` including indexed topics within the event logs.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param blockSignedAtAsc - Sort the transactions in chronological ascending order. By default, it's set to `false` and returns transactions in chronological descending order.
+         * @param noLogs - Setting this to `true` will omit decoded event logs, resulting in lighter and faster responses. By default it's set to `false`.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getTransactionsForAddress({
+            chainId,
+            address,
+            blockSignedAtAsc,
+            noLogs,
+            pageNumber,
+            pageSize,
+            quoteCurrency,
+            format,
+        }: {
+            chainId: ChainId
+            address: string
+            blockSignedAtAsc?: boolean
+            noLogs?: boolean
+            pageNumber?: number
+            pageSize?: number
+            quoteCurrency?: string
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/address/${address}/transactions_v2/`
+            const { data } = await this.http.get<CovalentResponse<TransactionResponse>>(url, {
+                params: {
+                    "block-signed-at-asc": blockSignedAtAsc,
+                    "no-logs": noLogs,
+                    "page-number": pageNumber,
+                    "page-size": pageSize,
+                    "quote-currency": quoteCurrency,
+                    format: format,
+                },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and `:tx_hash`, return the transaction data with their decoded event logs.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param txHash - Hex encoded transaction hash.
+         * @param noLogs - Setting this to `true` will omit decoded event logs, resulting in lighter and faster responses. By default it's set to `false`.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getATransaction({
+            chainId,
+            txHash,
+            noLogs,
+            pageNumber,
+            pageSize,
+            quoteCurrency,
+            format,
+        }: {
+            chainId: ChainId
+            txHash: string
+            noLogs?: boolean
+            pageNumber?: number
+            pageSize?: number
+            quoteCurrency?: string
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/transaction_v2/${txHash}/`
+            const { data } = await this.http.get<CovalentResponse<SingleTransactionResponse>>(url, {
+                params: { "no-logs": noLogs, "page-number": pageNumber, "page-size": pageSize, "quote-currency": quoteCurrency, format: format },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id`, wallet `:address` and `:contract-address`, return all ERC20 token contract transfers along with their historical prices at the time of their transfer.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param contractAddress - Smart contract address.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         * @param startingBlock - Starting block to define a block range.
+         * @param endingBlock - Ending block to define a block range.
+         */
+        async getErc20TokenTransfersForAddress({
+            chainId,
+            address,
+            contractAddress,
+            pageNumber,
+            pageSize,
+            quoteCurrency,
+            format,
+            startingBlock,
+            endingBlock,
+        }: {
+            chainId: ChainId
+            address: string
+            contractAddress: string
+            pageNumber?: number
+            pageSize?: number
+            quoteCurrency?: string
+            format?: string
+            startingBlock?: number
+            endingBlock?: number
+        }) {
+            const url = `/v1/${chainId}/address/${address}/transfers_v2/`
+            const { data } = await this.http.get<CovalentResponse<TransferResponse>>(url, {
+                params: {
+                    "contract-address": contractAddress,
+                    "page-number": pageNumber,
+                    "page-size": pageSize,
+                    "quote-currency": quoteCurrency,
+                    format: format,
+                    "starting-block": startingBlock,
+                    "ending-block": endingBlock,
+                },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and `:block_height`, return a single block at `:block_height`. If `:block_height` is set to the value `latest`, return the latest block available.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param blockHeight - The height of the block.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getABlock({
+            chainId,
+            blockHeight,
+            quoteCurrency,
+            format,
+        }: {
+            chainId: ChainId
+            blockHeight: string
+            quoteCurrency?: string
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/block_v2/${blockHeight}/`
+            const { data } = await this.http.get<CovalentResponse<SingleBlockResponse>>(url, {
+                params: { "quote-currency": quoteCurrency, format: format },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id`, `:start_date` and `:end_date`, return all the block height(s) of a particular chain within a date range. If the `:end_date` is set to `latest`, return every block height from the `:start_date` to now.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param startDate - The start datetime of the block height(s). (yyyy-MM-ddTHH:mm:ssZ), eg: 2020-01-01 or 2020-01-01T03:36:50z
+         * @param endDate - The ending datetime of the block height(s). (yyyy-MM-ddTHH:mm:ssZ), eg: 2020-01-02 or 2020-01-02T03:36:50z
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getBlockHeights({
+            chainId,
+            startDate,
+            endDate,
+            pageNumber,
+            pageSize,
+            format,
+        }: {
+            chainId: ChainId
+            startDate: string
+            endDate: string
+            pageNumber?: number
+            pageSize?: number
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/block_v2/${startDate}/${endDate}/`
+            const { data } = await this.http.get<CovalentResponse<SingleBlockResponse>>(url, {
+                params: { "page-number": pageNumber, "page-size": pageSize, format: format },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and `:dexname`, return pool information across all `XY=K` pools including LP token prices, reserves, exchange volumes and fees.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param dexname - One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.
+         * @param contractAddresses - If `contract-addresses` (a comma separated list) is present, only return the pools that contain these contracts.
+         * @param tickers - If `tickers` (a comma separated list) is present, only return the pools that contain these tickers.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param quoteCurrency - The requested fiat currency.
+         */
+        async getXyKPools({
+            chainId,
+            dexname,
+            contractAddresses,
+            tickers,
+            pageNumber,
+            pageSize,
+            quoteCurrency,
+        }: {
+            chainId: ChainId
+            dexname: string
+            contractAddresses?: string
+            tickers?: string
+            pageNumber?: number
+            pageSize?: number
+            quoteCurrency?: string
+        }) {
+            const url = `/v1/${chainId}/xy=k/${dexname}/pools/`
+            const { data } = await this.http.get<CovalentResponse<UniswapLikeExchangeListResponse>>(url, {
+                params: {
+                    "contract-addresses": contractAddresses,
+                    tickers: tickers,
+                    "page-number": pageNumber,
+                    "page-size": pageSize,
+                    "quote-currency": quoteCurrency,
+                },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and contract `:address`, return a paginated list of decoded log events emitted by a particular smart contract.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param startingBlock - Starting block to define a block range.
+         * @param endingBlock - Ending block to define a block range. Passing in `latest` uses the latest block height.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getLogEventsByContractAddress({
+            chainId,
+            address,
+            startingBlock,
+            endingBlock,
+            pageNumber,
+            pageSize,
+            quoteCurrency,
+            format,
+        }: {
+            chainId: ChainId
+            address: string
+            startingBlock: string
+            endingBlock: string
+            pageNumber?: number
+            pageSize?: number
+            quoteCurrency?: string
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/events/address/${address}/`
+            const { data } = await this.http.get<CovalentResponse<EventsListResponseType>>(url, {
+                params: {
+                    "starting-block": startingBlock,
+                    "ending-block": endingBlock,
+                    "page-number": pageNumber,
+                    "page-size": pageSize,
+                    "quote-currency": quoteCurrency,
+                    format: format,
+                },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id`, `:dexname` and `:address`, return pool information across all `XY=K` pools including LP token prices, reserves, exchange volumes and fees for address.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param dexname - One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param tickers - If `tickers` (a comma separated list) is present, only return the pools that contain these tickers.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param quoteCurrency - The requested fiat currency.
+         */
+        async getXyKPoolsByAddress({
+            chainId,
+            dexname,
+            address,
+            tickers,
+            pageNumber,
+            pageSize,
+            quoteCurrency,
+        }: {
+            chainId: ChainId
+            dexname: string
+            address: string
+            tickers?: string
+            pageNumber?: number
+            pageSize?: number
+            quoteCurrency?: string
+        }) {
+            const url = `/v1/${chainId}/xy=k/${dexname}/pools/address/${address}/`
+            const { data } = await this.http.get<CovalentResponse<UniswapLikeExchangeListResponse>>(url, {
+                params: { tickers: tickers, "page-number": pageNumber, "page-size": pageSize, "quote-currency": quoteCurrency },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and `:topic` hash(es), return a paginated list of decoded log events with one or more topic hashes separated by a comma.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param topic - Topic hash value from log records.
+         * @param secondaryTopics - Additional topic hash(es) to filter on -- padded & unpadded address fields are supported.
+         * @param startingBlock - Starting block to define a block range.
+         * @param endingBlock - Ending block to define a block range. Passing in `latest` uses the latest block height.
+         * @param senderAddress - The address of the sender.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getLogEventsByTopicHashEs({
+            chainId,
+            topic,
+            secondaryTopics,
+            startingBlock,
+            endingBlock,
+            senderAddress,
+            pageNumber,
+            pageSize,
+            quoteCurrency,
+            format,
+        }: {
+            chainId: ChainId
+            topic: string
+            secondaryTopics?: string
+            startingBlock: string
+            endingBlock: string
+            senderAddress?: string
+            pageNumber?: number
+            pageSize?: number
+            quoteCurrency?: string
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/events/topics/${topic}/`
+            const { data } = await this.http.get<CovalentResponse<EventsListResponseType>>(url, {
+                params: {
+                    "secondary-topics": secondaryTopics,
+                    "starting-block": startingBlock,
+                    "ending-block": endingBlock,
+                    "sender-address": senderAddress,
+                    "page-number": pageNumber,
+                    "page-size": pageSize,
+                    "quote-currency": quoteCurrency,
+                    format: format,
+                },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id`, `:dexname` and `:address`, return address exchange balances for a specific DEX.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param dexname - One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.
+         * @param quoteCurrency - The requested fiat currency.
+         */
+        async getXyKAddressExchangeBalances({
+            chainId,
+            address,
+            dexname,
+            quoteCurrency,
+        }: {
+            chainId: ChainId
+            address: string
+            dexname: string
+            quoteCurrency?: string
+        }) {
+            const url = `/v1/${chainId}/xy=k/${dexname}/address/${address}/balances/`
+            const { data } = await this.http.get<CovalentResponse<BalanceResponseType>>(url, { params: { "quote-currency": quoteCurrency } })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and wallet `:address`, return a paginated list of token holders. If `:block-height` is omitted, the latest block is used.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param blockHeight - Ending block to define a block range. Passing in `latest` uses the latest block height.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         * @param quoteCurrency - The requested fiat currency.
+         */
+        async getTokenHoldersAsOfAnyBlockHeight({
+            chainId,
+            address,
+            blockHeight,
+            pageNumber,
+            pageSize,
+            format,
+            quoteCurrency,
+        }: {
+            chainId: ChainId
+            address: string
+            blockHeight?: string
+            pageNumber?: number
+            pageSize?: number
+            format?: string
+            quoteCurrency?: string
+        }) {
+            const url = `/v1/${chainId}/tokens/${address}/token_holders/`
+            const { data } = await this.http.get<CovalentResponse<TokenHolderResponse>>(url, {
+                params: {
+                    "block-height": blockHeight,
+                    "page-number": pageNumber,
+                    "page-size": pageSize,
+                    format: format,
+                    "quote-currency": quoteCurrency,
+                },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and wallet `:address`, return a paginated list of token holders and their current/historical balances, where the token balance of the token holder changes between `:starting-block` and `:ending-block`.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param startingBlock - Starting block to define a block range.
+         * @param endingBlock - Ending block to define a block range.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getChangesInTokenHoldersBetweenTwoBlockHeights({
+            chainId,
+            address,
+            startingBlock,
+            endingBlock,
+            pageNumber,
+            pageSize,
+            quoteCurrency,
+            format,
+        }: {
+            chainId: ChainId
+            address: string
+            startingBlock: number
+            endingBlock?: number
+            pageNumber?: number
+            pageSize?: number
+            quoteCurrency?: string
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/tokens/${address}/token_holders_changes/`
+            const { data } = await this.http.get<CovalentResponse<TokenHolderDiff>>(url, {
+                params: {
+                    "starting-block": startingBlock,
+                    "ending-block": endingBlock,
+                    "page-number": pageNumber,
+                    "page-size": pageSize,
+                    "quote-currency": quoteCurrency,
+                    format: format,
+                },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and `:dexname`, return network exchange tokens for a specific DEX.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param dexname - One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         */
+        async getXyKNetworkExchangeTokens({
+            chainId,
+            dexname,
+            quoteCurrency,
+            pageNumber,
+            pageSize,
+        }: {
+            chainId: ChainId
+            dexname: string
+            quoteCurrency?: string
+            pageNumber?: number
+            pageSize?: number
+        }) {
+            const url = `/v1/${chainId}/xy=k/${dexname}/tokens/`
+            const { data } = await this.http.get<CovalentResponse<NetworkExchangeTokenResponse>>(url, {
+                params: { "quote-currency": quoteCurrency, "page-number": pageNumber, "page-size": pageSize },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+    * Returns a list of DEXes currently supported by the XY=K endpoints.
+      
+    */
+        async getXyKSupportedDeXes() {
+            const url = `/v1/xy=k/supported_dexes/`
+            const { data } = await this.http.get<CovalentResponse<BalanceResponseType>>(url, { params: {} })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and `:contract_address`, return a list of all token IDs for the NFT contract on the blockchain.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param contractAddress - Smart contract address.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getNftTokenIDsForContract({
+            chainId,
+            contractAddress,
+            pageNumber,
+            pageSize,
+            format,
+        }: {
+            chainId: ChainId
+            contractAddress: string
+            pageNumber?: number
+            pageSize?: number
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/tokens/${contractAddress}/nft_token_ids/`
+            const { data } = await this.http.get<CovalentResponse<TokenIdResponseType>>(url, {
+                params: { "page-number": pageNumber, "page-size": pageSize, format: format },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id`, `:dexname` and `:token_address`, return single network exchange token for a specific DEX.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param tokenAddress - token address
+         * @param dexname - One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param tickers - If `tickers` (a comma separated list) is present, only return the pools that contain these tickers.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         */
+        async getXyKSingleNetworkExchangeToken({
+            chainId,
+            tokenAddress,
+            dexname,
+            quoteCurrency,
+            tickers,
+            pageNumber,
+            pageSize,
+        }: {
+            chainId: ChainId
+            tokenAddress: string
+            dexname: string
+            quoteCurrency?: string
+            tickers?: string
+            pageNumber?: number
+            pageSize?: number
+        }) {
+            const url = `/v1/${chainId}/xy=k/${dexname}/tokens/address/${tokenAddress}/`
+            const { data } = await this.http.get<CovalentResponse<SingleNetworkExchangeTokenResponse>>(url, {
+                params: { "quote-currency": quoteCurrency, tickers: tickers, "page-number": pageNumber, "page-size": pageSize },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id`, `:contract_address` and `:token_id`, return a list of transactions.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param contractAddress - Smart contract address.
+         * @param tokenId - The token ID
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getNftTransactionsForContract({
+            chainId,
+            contractAddress,
+            tokenId,
+            pageNumber,
+            pageSize,
+            quoteCurrency,
+            format,
+        }: {
+            chainId: ChainId
+            contractAddress: string
+            tokenId: string
+            pageNumber?: number
+            pageSize?: number
+            quoteCurrency?: string
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/tokens/${contractAddress}/nft_transactions/${tokenId}/`
+            const { data } = await this.http.get<CovalentResponse<NftTransactionsResponseType>>(url, {
+                params: { "page-number": pageNumber, "page-size": pageSize, "quote-currency": quoteCurrency, format: format },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id`, `:dexname` and `:address`, return transactions for account address for a specific DEX.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param dexname - One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.
+         * @param quoteCurrency - The requested fiat currency.
+         */
+        async getXyKTransactionsForAccountAddress({
+            chainId,
+            address,
+            dexname,
+            quoteCurrency,
+        }: {
+            chainId: ChainId
+            address: string
+            dexname: string
+            quoteCurrency?: string
+        }) {
+            const url = `/v1/${chainId}/xy=k/${dexname}/address/${address}/transactions/`
+            const { data } = await this.http.get<CovalentResponse<AccountAddressTransactionsResponse>>(url, {
+                params: { "quote-currency": quoteCurrency },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id`, `:contract_address` and `:token_id`, fetch and return the external metadata. Both ERC721 as well as ERC1155 standards are supported.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param contractAddress - Smart contract address.
+         * @param tokenId - The token ID
+         * @param quoteCurrency - The requested fiat currency.
+         * @param format - If `format=csv`, return a flat CSV instead of JSON responses.
+         */
+        async getNftExternalMetadataForContract({
+            chainId,
+            contractAddress,
+            tokenId,
+            quoteCurrency,
+            format,
+        }: {
+            chainId: ChainId
+            contractAddress: string
+            tokenId: string
+            quoteCurrency?: string
+            format?: string
+        }) {
+            const url = `/v1/${chainId}/tokens/${contractAddress}/nft_metadata/${tokenId}/`
+            const { data } = await this.http.get<CovalentResponse<NFTMetaDataRsponseType>>(url, {
+                params: { "quote-currency": quoteCurrency, format: format },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id`, `:dexname` and `:token_address`, return transactions for token address for a specific DEX.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param tokenAddress - token address
+         * @param dexname - One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.
+         * @param quoteCurrency - The requested fiat currency.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         */
+        async getXyKTransactionsForTokenAddress({
+            chainId,
+            tokenAddress,
+            dexname,
+            quoteCurrency,
+            pageNumber,
+            pageSize,
+        }: {
+            chainId: ChainId
+            tokenAddress: string
+            dexname: string
+            quoteCurrency?: string
+            pageNumber?: number
+            pageSize?: number
+        }) {
+            const url = `/v1/${chainId}/xy=k/${dexname}/tokens/address/${tokenAddress}/transactions/`
+            const { data } = await this.http.get<CovalentResponse<TokenAddressTransactionsResponse>>(url, {
+                params: { "quote-currency": quoteCurrency, "page-number": pageNumber, "page-size": pageSize },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id`, `:dexname` and `:address`, return transactions for exchange for a specific DEX.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param address - Passing in an `ENS` resolves automatically.
+         * @param dexname - One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.
+         * @param quoteCurrency - The requested fiat currency.
+         */
+        async getXyKTransactionsForExchange({
+            chainId,
+            address,
+            dexname,
+            quoteCurrency,
+        }: {
+            chainId: ChainId
+            address: string
+            dexname: string
+            quoteCurrency?: string
+        }) {
+            const url = `/v1/${chainId}/xy=k/${dexname}/pools/address/${address}/transactions/`
+            const { data } = await this.http.get<CovalentResponse<ExchangeTransactionsResponse>>(url, {
+                params: { "quote-currency": quoteCurrency },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and `:dexname`, return ecosystem chart data for a specific DEX.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param dexname - One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.
+         * @param quoteCurrency - The requested fiat currency.
+         */
+        async getXyKEcosystemChartData({ chainId, dexname, quoteCurrency }: { chainId: ChainId; dexname: string; quoteCurrency?: string }) {
+            const url = `/v1/${chainId}/xy=k/${dexname}/ecosystem/`
+            const { data } = await this.http.get<CovalentResponse<EcosystemResponse>>(url, { params: { "quote-currency": quoteCurrency } })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+         * Given `:chain_id` and `:dexname`, return last synced block height data and latest block height for a specific DEX.
+         * @param chainId - Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         * @param dexname - One of `sushiswap`, `pancakeswap`, `quickswap`, `pangolin`, `spiritswap`, `spookyswap`.
+         * @param pageNumber - The specific page to be returned.
+         * @param pageSize - The number of results per page.
+         */
+        async getXyKHealthData({
+            chainId,
+            dexname,
+            pageNumber,
+            pageSize,
+        }: {
+            chainId: ChainId
+            dexname: string
+            pageNumber?: number
+            pageSize?: number
+        }) {
+            const url = `/v1/${chainId}/xy=k/${dexname}/health/`
+            const { data } = await this.http.get<CovalentResponse<HealthDataResponse>>(url, {
+                params: { "page-number": pageNumber, "page-size": pageSize },
+            })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+    * Returns a list of all chains.
+      
+    */
+        async getAllChains() {
+            const url = `/v1/chains/`
+            const { data } = await this.http.get<CovalentResponse<AllChainInfoResponse>>(url, { params: {} })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+
+        /**
+    * Returns a list of all chain statuses.
+      
+    */
+        async getAllChainStatuses() {
+            const url = `/v1/chains/status/`
+            const { data } = await this.http.get<CovalentResponse<ChainStatusResponse>>(url, { params: {} })
+            if (data.error) {
+                throw new Error(data.error_message)
+            }
+            return data.data
+        }
+    }
+    export type CovalentResponse<T> =
+        | {
+              data: T
+              error: false
+              error_code: null
+              error_message: null
+          }
+        | {
+              data: null
+              error: true
+              error_code: unknown
+              error_message: string
+          }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and `:contract_addresses`, return their historical prices. Can filter by date ranges and convert to `:quote_currency`. Only daily granularity is supported.
+     */
+    export interface AddressWithHistoricalPricesItem {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * The standard interface(s) supported for this token, eg: `ERC-20`.
+         */
+        supports_erc?: string[][]
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        update_at?: string
+        quote_currency?: string
+        prices?: HistoricalPriceItem[][]
+        items?: {
+            [k: string]: unknown
+        }[][]
+        [k: string]: unknown
+    }
+    export interface HistoricalPriceItem {
+        contract_metadata?: ContractMetadata
+        date?: string
+        price?: number
+        [k: string]: unknown
+    }
+    export interface ContractMetadata {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * The standard interface(s) supported for this token, eg: `ERC-20`.
+         */
+        supports_erc?: string[][]
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and wallet `:address`, return current token balances along with their spot prices. This endpoint supports a variety of token standards like ERC20, ERC721 and ERC1155. As a special case, network native tokens like ETH on Ethereum are also returned even though it's not a token contract.
+     */
+    export interface BalanceResponseType {
+        /**
+         * The requested wallet address.
+         */
+        address?: string
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        /**
+         * The next updated time.
+         */
+        next_update_at?: string
+        /**
+         * The requested fiat currency.
+         */
+        quote_currency?: string
+        items?: WalletBalanceItem[][]
+        [k: string]: unknown
+    }
+    export interface WalletBalanceItem {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * The standard interface(s) supported for this token, eg: `ERC-20`.
+         */
+        supports_erc?: string[][]
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        /**
+         * Last transferred date for a wallet
+         */
+        last_transferred_at?: string
+        /**
+         * Indicates if a token is the chain's native gas token, eg: ETH on Ethereum.
+         */
+        native_token?: boolean
+        /**
+         * One of `cryptocurrency`, `stablecoin`, `nft` or `dust`.
+         */
+        type?: string
+        /**
+         * The asset balance. Use `contract_decimals` to scale this balance for display purposes.
+         */
+        balance?: number
+        /**
+         * The asset balance 24 hours ago.
+         */
+        balance_24h?: number
+        /**
+         * The current spot exchange rate in `quote-currency`.
+         */
+        quote_rate?: number
+        /**
+         * The spot exchange rate in `quote-currency` as of 24 hours ago.
+         */
+        quote_rate_24h?: number
+        /**
+         * The current balance converted to fiat in `quote-currency`.
+         */
+        quote?: number
+        /**
+         * The current balance converted to fiat in `quote-currency` as of 24 hours ago.
+         */
+        quote_24h?: number
+        /**
+         * Array of NFTs that are held under this contract.
+         */
+        nft_data?: INFTMetadata[][]
+        [k: string]: unknown
+    }
+    /**
+     * Array of NFTs that are held under this contract.
+     */
+    export interface INFTMetadata {
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and wallet `:address`, return wallet value for the last 30 days at 24 hour interval timestamps.
+     */
+    export interface HistoricalPortfolioResponse {
+        /**
+         * The requested wallet address.
+         */
+        address?: string
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        /**
+         * The next updated time.
+         */
+        next_update_at?: string
+        /**
+         * The requested fiat currency.
+         */
+        quote_currency?: string
+        /**
+         * The requested chain ID.
+         */
+        chain_id?: number
+        /**
+         * List of tokens in portfolio
+         */
+        items?: {
+            [k: string]: unknown
+        }[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and wallet `:address`, return all transactions along with their decoded log events. This endpoint does a deep-crawl of the blockchain to retrieve all kinds of transactions that references the `:address` including indexed topics within the event logs.
+     */
+    export interface TransactionResponse {
+        /**
+         * The requested wallet address.
+         */
+        address?: string
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        /**
+         * The next updated time.
+         */
+        next_update_at?: string
+        /**
+         * The requested fiat currency.
+         */
+        quote_currency?: string
+        /**
+         * The requested chain ID.
+         */
+        chain_id?: number
+        /**
+         * The transactions.
+         */
+        items?: BlockTransactionWithLogEvents[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    /**
+     * The transactions.
+     */
+    export interface BlockTransactionWithLogEvents {
+        /**
+         * The signed time of the block.
+         */
+        block_signed_at?: string
+        /**
+         * The height of the block.
+         */
+        block_height?: number
+        /**
+         * The transaction hash.
+         */
+        tx_hash?: string
+        /**
+         * The transaction offset.
+         */
+        tx_offset?: number
+        /**
+         * The transaction status.
+         */
+        successful?: boolean
+        /**
+         * The address where the transaction is from.
+         */
+        from_address?: string
+        /**
+         * The label of `from` address.
+         */
+        from_address_label?: string
+        /**
+         * The address where the transaction is to.
+         */
+        to_address?: string
+        /**
+         * The label of `to` address.
+         */
+        to_address_label?: string
+        /**
+         * The value attached to this tx.
+         */
+        value?: number
+        /**
+         * The value attached in `quote-currency` to this tx.
+         */
+        value_quote?: number
+        /**
+         * The gas offered for this tx.
+         */
+        gas_offered?: number
+        /**
+         * The gas spent for this tx.
+         */
+        gas_spent?: number
+        /**
+         * The gas price at the time of this tx.
+         */
+        gas_price?: number
+        /**
+         * The total transaction fees paid for this tx.
+         */
+        fees_paid?: number
+        /**
+         * The gas spent in `quote-currency` denomination.
+         */
+        gas_quote?: number
+        /**
+         * The gas exchange rate at the time of Tx in `quote_currency`.
+         */
+        gas_quote_rate?: number
+        /**
+         * The log events.
+         */
+        log_events?: LogEventItem[][]
+        [k: string]: unknown
+    }
+    /**
+     * The log events.
+     */
+    export interface LogEventItem {
+        /**
+         * The signed time of the block.
+         */
+        block_signed_at?: string
+        /**
+         * The height of the block.
+         */
+        block_height?: number
+        /**
+         * The transaction offset.
+         */
+        tx_offset?: number
+        /**
+         * The log offset.
+         */
+        log_offset?: number
+        /**
+         * The transaction hash.
+         */
+        tx_hash?: string
+        raw_log_topics?: string[][]
+        /**
+         * Smart contract decimals.
+         */
+        sender_contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        sender_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        sender_contract_ticker_symbol?: string
+        /**
+         * The address of the sender.
+         */
+        sender_address?: string
+        /**
+         * The label of the sender address.
+         */
+        sender_address_label?: string
+        /**
+         * Smart contract URL.
+         */
+        sender_logo_url?: string
+        /**
+         * The log events in raw.
+         */
+        raw_log_data?: string
+        decoded?: DecodedItem
+        [k: string]: unknown
+    }
+    /**
+     * The decoded item.
+     */
+    export interface DecodedItem {
+        /**
+         * The name of the decoded item.
+         */
+        name?: string
+        /**
+         * The signature of the decoded item.
+         */
+        signature?: string
+        /**
+         * The parameters of the decoded item.
+         */
+        params?: DecodedParamItem[][]
+        [k: string]: unknown
+    }
+    /**
+     * The parameters of the decoded item.
+     */
+    export interface DecodedParamItem {
+        /**
+         * The name of the parameter.
+         */
+        name?: string
+        /**
+         * The type of the parameter.
+         */
+        type?: string
+        /**
+         * The index of the parameter.
+         */
+        indexed?: boolean
+        /**
+         * The decoded value of the parameter.
+         */
+        decoded?: boolean
+        /**
+         * The value of the parameter.
+         */
+        value?: {
+            [k: string]: unknown
+        }
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and `:tx_hash`, return the transaction data with their decoded event logs.
+     */
+    export interface SingleTransactionResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: BlockTransactionWithLogEvents[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface BlockTransactionWithLogEvents {
+        /**
+         * The signed time of the block.
+         */
+        block_signed_at?: string
+        /**
+         * The height of the block.
+         */
+        block_height?: number
+        /**
+         * The transaction hash.
+         */
+        tx_hash?: string
+        /**
+         * The transaction offset.
+         */
+        tx_offset?: number
+        /**
+         * The transaction status.
+         */
+        successful?: boolean
+        /**
+         * The address where the transaction is from.
+         */
+        from_address?: string
+        /**
+         * The label of `from` address.
+         */
+        from_address_label?: string
+        /**
+         * The address where the transaction is to.
+         */
+        to_address?: string
+        /**
+         * The label of `to` address.
+         */
+        to_address_label?: string
+        /**
+         * The value attached to this tx.
+         */
+        value?: number
+        /**
+         * The value attached in `quote-currency` to this tx.
+         */
+        value_quote?: number
+        /**
+         * The gas offered for this tx.
+         */
+        gas_offered?: number
+        /**
+         * The gas spent for this tx.
+         */
+        gas_spent?: number
+        /**
+         * The gas price at the time of this tx.
+         */
+        gas_price?: number
+        /**
+         * The total transaction fees paid for this tx.
+         */
+        fees_paid?: number
+        /**
+         * The gas spent in `quote-currency` denomination.
+         */
+        gas_quote?: number
+        /**
+         * The gas exchange rate at the time of Tx in `quote_currency`.
+         */
+        gas_quote_rate?: number
+        /**
+         * The log events.
+         */
+        log_events?: LogEventItem[][]
+        [k: string]: unknown
+    }
+    /**
+     * The log events.
+     */
+    export interface LogEventItem {
+        /**
+         * The signed time of the block.
+         */
+        block_signed_at?: string
+        /**
+         * The height of the block.
+         */
+        block_height?: number
+        /**
+         * The transaction offset.
+         */
+        tx_offset?: number
+        /**
+         * The log offset.
+         */
+        log_offset?: number
+        /**
+         * The transaction hash.
+         */
+        tx_hash?: string
+        raw_log_topics?: string[][]
+        /**
+         * Smart contract decimals.
+         */
+        sender_contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        sender_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        sender_contract_ticker_symbol?: string
+        /**
+         * The address of the sender.
+         */
+        sender_address?: string
+        /**
+         * The label of the sender address.
+         */
+        sender_address_label?: string
+        /**
+         * Smart contract URL.
+         */
+        sender_logo_url?: string
+        /**
+         * The log events in raw.
+         */
+        raw_log_data?: string
+        decoded?: DecodedItem
+        [k: string]: unknown
+    }
+    /**
+     * The decoded item.
+     */
+    export interface DecodedItem {
+        /**
+         * The name of the decoded item.
+         */
+        name?: string
+        /**
+         * The signature of the decoded item.
+         */
+        signature?: string
+        /**
+         * The parameters of the decoded item.
+         */
+        params?: DecodedParamItem[][]
+        [k: string]: unknown
+    }
+    /**
+     * The parameters of the decoded item.
+     */
+    export interface DecodedParamItem {
+        /**
+         * The name of the parameter.
+         */
+        name?: string
+        /**
+         * The type of the parameter.
+         */
+        type?: string
+        /**
+         * The index of the parameter.
+         */
+        indexed?: boolean
+        /**
+         * The decoded value of the parameter.
+         */
+        decoded?: boolean
+        /**
+         * The value of the parameter.
+         */
+        value?: {
+            [k: string]: unknown
+        }
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id`, wallet `:address` and `:contract-address`, return all ERC20 token contract transfers along with their historical prices at the time of their transfer.
+     */
+    export interface TransferResponse {
+        /**
+         * The requested wallet address.
+         */
+        address?: string
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        /**
+         * The next updated time.
+         */
+        next_update_at?: string
+        /**
+         * The requested fiat currency.
+         */
+        quote_currency?: string
+        /**
+         * The requested chain ID.
+         */
+        chain_id?: number
+        /**
+         * The transactions.
+         */
+        items?: BlockTransactionWithContractTransfers[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    /**
+     * The transactions.
+     */
+    export interface BlockTransactionWithContractTransfers {
+        /**
+         * The signed time of the block.
+         */
+        block_signed_at?: string
+        /**
+         * The height of the block.
+         */
+        block_height?: number
+        /**
+         * The transaction hash.
+         */
+        tx_hash?: string
+        /**
+         * The transaction offset.
+         */
+        tx_offset?: number
+        /**
+         * The transaction status.
+         */
+        successful?: boolean
+        /**
+         * The address where the transaction is from.
+         */
+        from_address?: string
+        /**
+         * The label of `from` address.
+         */
+        from_address_label?: string
+        /**
+         * The address where the transaction is to.
+         */
+        to_address?: string
+        /**
+         * The label of `to` address.
+         */
+        to_address_label?: string
+        /**
+         * The value attached to this tx.
+         */
+        value?: number
+        /**
+         * The value attached in `quote-currency` to this tx.
+         */
+        value_quote?: number
+        /**
+         * The gas offered for this tx.
+         */
+        gas_offered?: number
+        /**
+         * The gas spent for this tx.
+         */
+        gas_spent?: number
+        /**
+         * The gas price at the time of this tx.
+         */
+        gas_price?: number
+        /**
+         * The total transaction fees paid for this tx.
+         */
+        fees_paid?: number
+        /**
+         * The gas spent in `quote-currency` denomination.
+         */
+        gas_quote?: number
+        /**
+         * The gas exchange rate at the time of Tx in `quote_currency`.
+         */
+        gas_quote_rate?: number
+        /**
+         * Transfer items.
+         */
+        transfers?: TokenTransferItem[][]
+        [k: string]: unknown
+    }
+    /**
+     * Transfer items.
+     */
+    export interface TokenTransferItem {
+        /**
+         * The signed time of the block.
+         */
+        block_signed_at?: string
+        /**
+         * The transaction hash.
+         */
+        tx_hash?: string
+        /**
+         * The address where the transfer is from.
+         */
+        from_address?: string
+        /**
+         * The label of `from` address.
+         */
+        from_address_label?: string
+        /**
+         * The address where the transfer is to.
+         */
+        to_address?: string
+        /**
+         * The label of `to` address.
+         */
+        to_address_label?: string
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        /**
+         * IN/OUT.
+         */
+        transfer_type?: string
+        /**
+         * The delta attached to this transfer.
+         */
+        delta?: number
+        /**
+         * The transfer balance. Use `contract_decimals` to scale this balance for display purposes.
+         */
+        balance?: number
+        /**
+         * The current spot exchange rate in `quote-currency`.
+         */
+        quote_rate?: number
+        /**
+         * The current delta converted to fiat in `quote-currency`.
+         */
+        delta_quote?: number
+        /**
+         * The current balance converted to fiat in `quote-currency`.
+         */
+        balance_quote?: number
+        /**
+         * Additional details on which transfer events were invoked. Defaults to `true`.
+         */
+        method_calls?: MethodCallsForTransfers[][]
+        [k: string]: unknown
+    }
+    /**
+     * Additional details on which transfer events were invoked. Defaults to `true`.
+     */
+    export interface MethodCallsForTransfers {
+        /**
+         * The address of the sender.
+         */
+        sender_address?: string
+        /**
+         * The name of the decoded item.
+         */
+        method?: string
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and `:block_height`, return a single block at `:block_height`. If `:block_height` is set to the value `latest`, return the latest block available.
+     */
+    export interface SingleBlockResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: Block[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface Block {
+        /**
+         * The signed time of the block.
+         */
+        signed_at?: string
+        /**
+         * The height of the block.
+         */
+        height?: number
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id`, `:start_date` and `:end_date`, return all the block height(s) of a particular chain within a date range. If the `:end_date` is set to `latest`, return every block height from the `:start_date` to now.
+     */
+    export interface SingleBlockResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: Block[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface Block {
+        /**
+         * The signed time of the block.
+         */
+        signed_at?: string
+        /**
+         * The height of the block.
+         */
+        height?: number
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and `:dexname`, return pool information across all `XY=K` pools including LP token prices, reserves, exchange volumes and fees.
+     */
+    export interface UniswapLikeExchangeListResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: ExchangeVolumeV2[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface ExchangeVolumeV2 {
+        exchange?: string
+        swap_count_24h?: number
+        total_liquidity_quote?: number
+        volume_24h_quote?: number
+        fee_24h_quote?: number
+        total_supply?: number
+        quote_rate?: number
+        block_height?: number
+        token_0?: TokenV2
+        token_1?: TokenV2
+        chain_name?: string
+        chain_id?: string
+        dex_name?: string
+        volume_7d_quote?: number
+        annualized_fee?: number
+        [k: string]: unknown
+    }
+    export interface TokenV2 {
+        contract_address?: string
+        contract_name?: string
+        volume_in_24h?: number
+        volume_out_24h?: number
+        quote_rate?: number
+        reserve?: number
+        logo_url?: string
+        contract_ticker_symbol?: string
+        contract_decimals?: number
+        volume_in_7d?: number
+        volume_out_7d?: number
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and contract `:address`, return a paginated list of decoded log events emitted by a particular smart contract.
+     */
+    export interface EventsListResponseType {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: LogEventItem[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface LogEventItem {
+        /**
+         * The signed time of the block.
+         */
+        block_signed_at?: string
+        /**
+         * The height of the block.
+         */
+        block_height?: number
+        /**
+         * The transaction offset.
+         */
+        tx_offset?: number
+        /**
+         * The log offset.
+         */
+        log_offset?: number
+        /**
+         * The transaction hash.
+         */
+        tx_hash?: string
+        raw_log_topics?: string[][]
+        /**
+         * Smart contract decimals.
+         */
+        sender_contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        sender_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        sender_contract_ticker_symbol?: string
+        /**
+         * The address of the sender.
+         */
+        sender_address?: string
+        /**
+         * The label of the sender address.
+         */
+        sender_address_label?: string
+        /**
+         * Smart contract URL.
+         */
+        sender_logo_url?: string
+        /**
+         * The log events in raw.
+         */
+        raw_log_data?: string
+        decoded?: DecodedItem
+        [k: string]: unknown
+    }
+    /**
+     * The decoded item.
+     */
+    export interface DecodedItem {
+        /**
+         * The name of the decoded item.
+         */
+        name?: string
+        /**
+         * The signature of the decoded item.
+         */
+        signature?: string
+        /**
+         * The parameters of the decoded item.
+         */
+        params?: DecodedParamItem[][]
+        [k: string]: unknown
+    }
+    /**
+     * The parameters of the decoded item.
+     */
+    export interface DecodedParamItem {
+        /**
+         * The name of the parameter.
+         */
+        name?: string
+        /**
+         * The type of the parameter.
+         */
+        type?: string
+        /**
+         * The index of the parameter.
+         */
+        indexed?: boolean
+        /**
+         * The decoded value of the parameter.
+         */
+        decoded?: boolean
+        /**
+         * The value of the parameter.
+         */
+        value?: {
+            [k: string]: unknown
+        }
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id`, `:dexname` and `:address`, return pool information across all `XY=K` pools including LP token prices, reserves, exchange volumes and fees for address.
+     */
+    export interface UniswapLikeExchangeListResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: ExchangeVolumeV2[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface ExchangeVolumeV2 {
+        exchange?: string
+        swap_count_24h?: number
+        total_liquidity_quote?: number
+        volume_24h_quote?: number
+        fee_24h_quote?: number
+        total_supply?: number
+        quote_rate?: number
+        block_height?: number
+        token_0?: TokenV2
+        token_1?: TokenV2
+        chain_name?: string
+        chain_id?: string
+        dex_name?: string
+        volume_7d_quote?: number
+        annualized_fee?: number
+        [k: string]: unknown
+    }
+    export interface TokenV2 {
+        contract_address?: string
+        contract_name?: string
+        volume_in_24h?: number
+        volume_out_24h?: number
+        quote_rate?: number
+        reserve?: number
+        logo_url?: string
+        contract_ticker_symbol?: string
+        contract_decimals?: number
+        volume_in_7d?: number
+        volume_out_7d?: number
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and `:topic` hash(es), return a paginated list of decoded log events with one or more topic hashes separated by a comma.
+     */
+    export interface EventsListResponseType {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: LogEventItem[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface LogEventItem {
+        /**
+         * The signed time of the block.
+         */
+        block_signed_at?: string
+        /**
+         * The height of the block.
+         */
+        block_height?: number
+        /**
+         * The transaction offset.
+         */
+        tx_offset?: number
+        /**
+         * The log offset.
+         */
+        log_offset?: number
+        /**
+         * The transaction hash.
+         */
+        tx_hash?: string
+        raw_log_topics?: string[][]
+        /**
+         * Smart contract decimals.
+         */
+        sender_contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        sender_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        sender_contract_ticker_symbol?: string
+        /**
+         * The address of the sender.
+         */
+        sender_address?: string
+        /**
+         * The label of the sender address.
+         */
+        sender_address_label?: string
+        /**
+         * Smart contract URL.
+         */
+        sender_logo_url?: string
+        /**
+         * The log events in raw.
+         */
+        raw_log_data?: string
+        decoded?: DecodedItem
+        [k: string]: unknown
+    }
+    /**
+     * The decoded item.
+     */
+    export interface DecodedItem {
+        /**
+         * The name of the decoded item.
+         */
+        name?: string
+        /**
+         * The signature of the decoded item.
+         */
+        signature?: string
+        /**
+         * The parameters of the decoded item.
+         */
+        params?: DecodedParamItem[][]
+        [k: string]: unknown
+    }
+    /**
+     * The parameters of the decoded item.
+     */
+    export interface DecodedParamItem {
+        /**
+         * The name of the parameter.
+         */
+        name?: string
+        /**
+         * The type of the parameter.
+         */
+        type?: string
+        /**
+         * The index of the parameter.
+         */
+        indexed?: boolean
+        /**
+         * The decoded value of the parameter.
+         */
+        decoded?: boolean
+        /**
+         * The value of the parameter.
+         */
+        value?: {
+            [k: string]: unknown
+        }
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id`, `:dexname` and `:address`, return address exchange balances for a specific DEX.
+     */
+    export interface BalanceResponseType {
+        address?: string
+        updated_at?: string
+        next_update_at?: string
+        quote_currency?: string
+        uniswap_v2?: ContainerU
+        [k: string]: unknown
+    }
+    export interface ContainerU {
+        balances?: UniswapV2BalanceItem[][]
+        [k: string]: unknown
+    }
+    export interface UniswapV2BalanceItem {
+        token_0?: UniswapToken
+        token_1?: UniswapToken
+        pool_token?: UniswapTokenWithSupply
+        [k: string]: unknown
+    }
+    export interface UniswapToken {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        /**
+         * Current balance.
+         */
+        balance?: number
+        /**
+         * The current balance converted to fiat in `quote-currency`.
+         */
+        quote?: number
+        /**
+         * The current spot exchange rate in `quote-currency`.
+         */
+        quote_rate?: number
+        [k: string]: unknown
+    }
+    export interface UniswapTokenWithSupply {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        /**
+         * Current balance.
+         */
+        balance?: number
+        /**
+         * The current balance converted to fiat in `quote-currency`.
+         */
+        quote?: number
+        /**
+         * The current spot exchange rate in `quote-currency`.
+         */
+        quote_rate?: number
+        /**
+         * Total supply of this pool token.
+         */
+        total_supply?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and wallet `:address`, return a paginated list of token holders. If `:block-height` is omitted, the latest block is used.
+     */
+    export interface TokenHolderResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: TokenHolder[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface TokenHolder {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * The standard interface(s) supported for this token, eg: `ERC-20`.
+         */
+        supports_erc?: string[][]
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        /**
+         * The address of token holder.
+         */
+        address?: string
+        /**
+         * The balance of token holder.
+         */
+        balance?: number
+        /**
+         * The total supply of the token.
+         */
+        total_supply?: number
+        /**
+         * The height of the block.
+         */
+        block_height?: number
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and wallet `:address`, return a paginated list of token holders and their current/historical balances, where the token balance of the token holder changes between `:starting-block` and `:ending-block`.
+     */
+    export interface TokenHolderDiff {
+        /**
+         * The token holder.
+         */
+        token_holder?: string
+        /**
+         * The starting block balance.
+         */
+        prev_balance?: number
+        /**
+         * The starting block height.
+         */
+        prev_block_height?: number
+        /**
+         * The ending block balance.
+         */
+        next_balance?: number
+        /**
+         * The ending block height.
+         */
+        next_block_height?: number
+        /**
+         * The difference of the balance.
+         */
+        diff?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and `:dexname`, return network exchange tokens for a specific DEX.
+     */
+    export interface NetworkExchangeTokenResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: TokenV2Volume[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface TokenV2Volume {
+        chain_name?: string
+        chain_id?: string
+        dex_name?: string
+        contract_address?: string
+        contract_name?: string
+        total_liquidity?: number
+        total_volume_24h?: number
+        logo_url?: string
+        contract_ticker_symbol?: string
+        contract_decimals?: number
+        swap_count_24h?: number
+        quote_rate?: number
+        total_liquidity_quote?: number
+        total_volume_24h_quote?: number
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Returns a list of DEXes currently supported by the XY=K endpoints.
+     */
+    export interface BalanceResponseType {
+        address?: string
+        updated_at?: string
+        next_update_at?: string
+        quote_currency?: string
+        uniswap_v2?: ContainerU
+        [k: string]: unknown
+    }
+    export interface ContainerU {
+        balances?: UniswapV2BalanceItem[][]
+        [k: string]: unknown
+    }
+    export interface UniswapV2BalanceItem {
+        token_0?: UniswapToken
+        token_1?: UniswapToken
+        pool_token?: UniswapTokenWithSupply
+        [k: string]: unknown
+    }
+    export interface UniswapToken {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        /**
+         * Current balance.
+         */
+        balance?: number
+        /**
+         * The current balance converted to fiat in `quote-currency`.
+         */
+        quote?: number
+        /**
+         * The current spot exchange rate in `quote-currency`.
+         */
+        quote_rate?: number
+        [k: string]: unknown
+    }
+    export interface UniswapTokenWithSupply {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        /**
+         * Current balance.
+         */
+        balance?: number
+        /**
+         * The current balance converted to fiat in `quote-currency`.
+         */
+        quote?: number
+        /**
+         * The current spot exchange rate in `quote-currency`.
+         */
+        quote_rate?: number
+        /**
+         * Total supply of this pool token.
+         */
+        total_supply?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and `:contract_address`, return a list of all token IDs for the NFT contract on the blockchain.
+     */
+    export interface TokenIdResponseType {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: TokenIdResponse[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface TokenIdResponse {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * The standard interface(s) supported for this token, eg: `ERC-20`.
+         */
+        supports_erc?: string[][]
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        /**
+         * The list of token ids under the contract address.
+         */
+        token_id?: number
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id`, `:dexname` and `:token_address`, return single network exchange token for a specific DEX.
+     */
+    export interface SingleNetworkExchangeTokenResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: ExchangeVolumeWithVolumeAndLiquidityTimeseries[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface ExchangeVolumeWithVolumeAndLiquidityTimeseries {
+        dex_name?: string
+        chain_id?: string
+        exchange?: string
+        swap_count_24h?: number
+        total_liquidity_quote?: number
+        volume_24h_quote?: number
+        fee_24h_quote?: number
+        volume_7d_quote?: number
+        annualized_fee?: number
+        total_supply?: number
+        quote_rate?: number
+        quote_currency?: string
+        block_height?: number
+        token_0?: TokenV2
+        token_1?: TokenV2
+        token0_reserve_quote?: number
+        token1_reserve_quote?: number
+        volume_timeseries_7d?: UniswapLikeVolumeChartWithQuote[][]
+        volume_timeseries_30d?: UniswapLikeVolumeChartWithQuote[][]
+        liquidity_timeseries_7d?: UniswapLikeLiquidityChartWithQuote[][]
+        liquidity_timeseries_30d?: UniswapLikeLiquidityChartWithQuote[][]
+        price_timeseries_7d?: UniswapLikePriceChartWithQuote[][]
+        price_timeseries_30d?: UniswapLikePriceChartWithQuote[][]
+        [k: string]: unknown
+    }
+    export interface TokenV2 {
+        contract_address?: string
+        contract_name?: string
+        volume_in_24h?: number
+        volume_out_24h?: number
+        quote_rate?: number
+        reserve?: number
+        logo_url?: string
+        contract_ticker_symbol?: string
+        contract_decimals?: number
+        volume_in_7d?: number
+        volume_out_7d?: number
+        [k: string]: unknown
+    }
+    export interface UniswapLikeVolumeChartWithQuote {
+        dex_name?: string
+        chain_id?: string
+        dt?: string
+        exchange?: string
+        sum_amount0in?: number
+        sum_amount0out?: number
+        sum_amount1in?: number
+        sum_amount1out?: number
+        volume_quote?: number
+        token0_quote_rate?: number
+        token1_quote_rate?: number
+        swap_count_24?: number
+        [k: string]: unknown
+    }
+    export interface UniswapLikeLiquidityChartWithQuote {
+        dex_name?: string
+        chain_id?: string
+        dt?: string
+        exchange?: string
+        r0_c?: number
+        r1_c?: number
+        liquidity_quote?: number
+        token0_quote_rate?: number
+        token1_quote_rate?: number
+        [k: string]: unknown
+    }
+    export interface UniswapLikePriceChartWithQuote {
+        dex_name?: string
+        chain_id?: string
+        dt?: string
+        exchange?: string
+        price_of_token0_in_token1?: number
+        price_of_token0_in_token1_description?: string
+        price_of_token1_in_token0?: number
+        price_of_token1_in_token0_description?: string
+        quote_currency?: string
+        price_of_token0_in_quote_currency?: number
+        price_of_token1_in_quote_currency?: number
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id`, `:contract_address` and `:token_id`, return a list of transactions.
+     */
+    export interface NftTransactionsResponseType {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: NftTransactionsResponse[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface NftTransactionsResponse {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * The standard interface(s) supported for this token, eg: `ERC-20`.
+         */
+        supports_erc?: string[][]
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        /**
+         * One of `cryptocurrency`, `stablecoin`, `nft` or `dust`.
+         */
+        type?: string
+        /**
+         * The nft transactions.
+         */
+        nft_transactions?: BlockTransactionWithLogEvents[][]
+        [k: string]: unknown
+    }
+    /**
+     * The nft transactions.
+     */
+    export interface BlockTransactionWithLogEvents {
+        /**
+         * The signed time of the block.
+         */
+        block_signed_at?: string
+        /**
+         * The height of the block.
+         */
+        block_height?: number
+        /**
+         * The transaction hash.
+         */
+        tx_hash?: string
+        /**
+         * The transaction offset.
+         */
+        tx_offset?: number
+        /**
+         * The transaction status.
+         */
+        successful?: boolean
+        /**
+         * The address where the transaction is from.
+         */
+        from_address?: string
+        /**
+         * The label of `from` address.
+         */
+        from_address_label?: string
+        /**
+         * The address where the transaction is to.
+         */
+        to_address?: string
+        /**
+         * The label of `to` address.
+         */
+        to_address_label?: string
+        /**
+         * The value attached to this tx.
+         */
+        value?: number
+        /**
+         * The value attached in `quote-currency` to this tx.
+         */
+        value_quote?: number
+        /**
+         * The gas offered for this tx.
+         */
+        gas_offered?: number
+        /**
+         * The gas spent for this tx.
+         */
+        gas_spent?: number
+        /**
+         * The gas price at the time of this tx.
+         */
+        gas_price?: number
+        /**
+         * The total transaction fees paid for this tx.
+         */
+        fees_paid?: number
+        /**
+         * The gas spent in `quote-currency` denomination.
+         */
+        gas_quote?: number
+        /**
+         * The gas exchange rate at the time of Tx in `quote_currency`.
+         */
+        gas_quote_rate?: number
+        /**
+         * The log events.
+         */
+        log_events?: LogEventItem[][]
+        [k: string]: unknown
+    }
+    /**
+     * The log events.
+     */
+    export interface LogEventItem {
+        /**
+         * The signed time of the block.
+         */
+        block_signed_at?: string
+        /**
+         * The height of the block.
+         */
+        block_height?: number
+        /**
+         * The transaction offset.
+         */
+        tx_offset?: number
+        /**
+         * The log offset.
+         */
+        log_offset?: number
+        /**
+         * The transaction hash.
+         */
+        tx_hash?: string
+        raw_log_topics?: string[][]
+        /**
+         * Smart contract decimals.
+         */
+        sender_contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        sender_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        sender_contract_ticker_symbol?: string
+        /**
+         * The address of the sender.
+         */
+        sender_address?: string
+        /**
+         * The label of the sender address.
+         */
+        sender_address_label?: string
+        /**
+         * Smart contract URL.
+         */
+        sender_logo_url?: string
+        /**
+         * The log events in raw.
+         */
+        raw_log_data?: string
+        decoded?: DecodedItem
+        [k: string]: unknown
+    }
+    /**
+     * The decoded item.
+     */
+    export interface DecodedItem {
+        /**
+         * The name of the decoded item.
+         */
+        name?: string
+        /**
+         * The signature of the decoded item.
+         */
+        signature?: string
+        /**
+         * The parameters of the decoded item.
+         */
+        params?: DecodedParamItem[][]
+        [k: string]: unknown
+    }
+    /**
+     * The parameters of the decoded item.
+     */
+    export interface DecodedParamItem {
+        /**
+         * The name of the parameter.
+         */
+        name?: string
+        /**
+         * The type of the parameter.
+         */
+        type?: string
+        /**
+         * The index of the parameter.
+         */
+        indexed?: boolean
+        /**
+         * The decoded value of the parameter.
+         */
+        decoded?: boolean
+        /**
+         * The value of the parameter.
+         */
+        value?: {
+            [k: string]: unknown
+        }
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id`, `:dexname` and `:address`, return transactions for account address for a specific DEX.
+     */
+    export interface AccountAddressTransactionsResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: ExchangeTransaction[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface ExchangeTransaction {
+        block_signed_at?: string
+        tx_hash?: string
+        act?: string
+        address?: string
+        amount_0?: number
+        amount_1?: number
+        amount_0_in?: number
+        amount_1_in?: number
+        amount_0_out?: number
+        amount_1_out?: number
+        to_address?: string
+        from_address?: string
+        sender_address?: string
+        total_quote?: number
+        quote_currency?: string
+        token_0?: ContractMetadata
+        token_1?: ContractMetadata
+        token_0_quote_rate?: number
+        token_1_quote_rate?: number
+        [k: string]: unknown
+    }
+    export interface ContractMetadata {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * The standard interface(s) supported for this token, eg: `ERC-20`.
+         */
+        supports_erc?: string[][]
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id`, `:contract_address` and `:token_id`, fetch and return the external metadata. Both ERC721 as well as ERC1155 standards are supported.
+     */
+    export interface NFTMetaDataRsponseType {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: WalletBalanceItem[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface WalletBalanceItem {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * The standard interface(s) supported for this token, eg: `ERC-20`.
+         */
+        supports_erc?: string[][]
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        /**
+         * Last transferred date for a wallet
+         */
+        last_transferred_at?: string
+        /**
+         * Indicates if a token is the chain's native gas token, eg: ETH on Ethereum.
+         */
+        native_token?: boolean
+        /**
+         * One of `cryptocurrency`, `stablecoin`, `nft` or `dust`.
+         */
+        type?: string
+        /**
+         * The asset balance. Use `contract_decimals` to scale this balance for display purposes.
+         */
+        balance?: number
+        /**
+         * The asset balance 24 hours ago.
+         */
+        balance_24h?: number
+        /**
+         * The current spot exchange rate in `quote-currency`.
+         */
+        quote_rate?: number
+        /**
+         * The spot exchange rate in `quote-currency` as of 24 hours ago.
+         */
+        quote_rate_24h?: number
+        /**
+         * The current balance converted to fiat in `quote-currency`.
+         */
+        quote?: number
+        /**
+         * The current balance converted to fiat in `quote-currency` as of 24 hours ago.
+         */
+        quote_24h?: number
+        /**
+         * Array of NFTs that are held under this contract.
+         */
+        nft_data?: INFTMetadata[][]
+        [k: string]: unknown
+    }
+    /**
+     * Array of NFTs that are held under this contract.
+     */
+    export interface INFTMetadata {
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id`, `:dexname` and `:token_address`, return transactions for token address for a specific DEX.
+     */
+    export interface TokenAddressTransactionsResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: ExchangeTransaction[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface ExchangeTransaction {
+        block_signed_at?: string
+        tx_hash?: string
+        act?: string
+        address?: string
+        amount_0?: number
+        amount_1?: number
+        amount_0_in?: number
+        amount_1_in?: number
+        amount_0_out?: number
+        amount_1_out?: number
+        to_address?: string
+        from_address?: string
+        sender_address?: string
+        total_quote?: number
+        quote_currency?: string
+        token_0?: ContractMetadata
+        token_1?: ContractMetadata
+        token_0_quote_rate?: number
+        token_1_quote_rate?: number
+        [k: string]: unknown
+    }
+    export interface ContractMetadata {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * The standard interface(s) supported for this token, eg: `ERC-20`.
+         */
+        supports_erc?: string[][]
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id`, `:dexname` and `:address`, return transactions for exchange for a specific DEX.
+     */
+    export interface ExchangeTransactionsResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: ExchangeTransaction[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface ExchangeTransaction {
+        block_signed_at?: string
+        tx_hash?: string
+        act?: string
+        address?: string
+        amount_0?: number
+        amount_1?: number
+        amount_0_in?: number
+        amount_1_in?: number
+        amount_0_out?: number
+        amount_1_out?: number
+        to_address?: string
+        from_address?: string
+        sender_address?: string
+        total_quote?: number
+        quote_currency?: string
+        token_0?: ContractMetadata
+        token_1?: ContractMetadata
+        token_0_quote_rate?: number
+        token_1_quote_rate?: number
+        [k: string]: unknown
+    }
+    export interface ContractMetadata {
+        /**
+         * Smart contract decimals.
+         */
+        contract_decimals?: number
+        /**
+         * Smart contract name.
+         */
+        contract_name?: string
+        /**
+         * Smart contract ticker symbol.
+         */
+        contract_ticker_symbol?: string
+        /**
+         * Smart contract address.
+         */
+        contract_address?: string
+        /**
+         * The standard interface(s) supported for this token, eg: `ERC-20`.
+         */
+        supports_erc?: string[][]
+        /**
+         * Smart contract URL.
+         */
+        logo_url?: string
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and `:dexname`, return ecosystem chart data for a specific DEX.
+     */
+    export interface EcosystemResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: UniswapLikeEcosystemCharts[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface UniswapLikeEcosystemCharts {
+        dex_name?: string
+        chain_id?: string
+        quote_currency?: string
+        gas_token_price_quote?: number
+        total_swaps_24h?: number
+        total_active_pairs_7d?: number
+        total_fees_24h?: number
+        volume_chart_7d?: UniswapLikeVolumeEcosystemChart[][]
+        volume_chart_30d?: UniswapLikeVolumeEcosystemChart[][]
+        liquidity_chart_7d?: UniswapLikeLiquidityEcosystemChart[][]
+        liquidity_chart_30d?: UniswapLikeLiquidityEcosystemChart[][]
+        [k: string]: unknown
+    }
+    export interface UniswapLikeVolumeEcosystemChart {
+        dex_name?: string
+        chain_id?: string
+        dt?: string
+        quote_currency?: string
+        volume_quote?: number
+        swap_count_24?: number
+        [k: string]: unknown
+    }
+    export interface UniswapLikeLiquidityEcosystemChart {
+        dex_name?: string
+        chain_id?: string
+        dt?: string
+        quote_currency?: string
+        liquidity_quote?: number
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Given `:chain_id` and `:dexname`, return last synced block height data and latest block height for a specific DEX.
+     */
+    export interface HealthDataResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: HealthData[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface HealthData {
+        synced_block_height?: number
+        synced_block_signed_at?: string
+        latest_block_height?: number
+        latest_block_signed_at?: string
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Returns a list of all chains.
+     */
+    export interface AllChainInfoResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: GenericChainInfoDisplay[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface GenericChainInfoDisplay {
+        /**
+         * Name of chain
+         */
+        name?: string
+        /**
+         * Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         */
+        chain_id?: string
+        is_testnet?: boolean
+        db_schema_name?: string
+        label?: string
+        logo_url?: string
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+
+    /* eslint-disable */
+    /**
+     * This file was automatically generated by json-schema-to-typescript.
+     * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
+     * and run json-schema-to-typescript to regenerate this file.
+     */
+
+    /**
+     * Returns a list of all chain statuses.
+     */
+    export interface ChainStatusResponse {
+        /**
+         * The updated time.
+         */
+        updated_at?: string
+        items?: GenericChainInfoStatusDisplay[][]
+        pagination?: AppliedPagination
+        [k: string]: unknown
+    }
+    export interface GenericChainInfoStatusDisplay {
+        /**
+         * Name of chain
+         */
+        name?: string
+        /**
+         * Chain ID of the Blockchain being queried. Currently supports `1` for Ethereum Mainnet, `137` for Polygon/Matic Mainnet, `80001` for Polygon/Matic Mumbai Testnet, `56` for Binance Smart Chain, `43114` for Avalanche C-Chain Mainnet, `43113` for Fuji C-Chain Testnet, and `250` for Fantom Opera Mainnet.
+         */
+        chain_id?: string
+        is_testnet?: boolean
+        logo_url?: string
+        /**
+         * The height of the block.
+         */
+        synced_block_height?: number
+        synced_blocked_signed_at?: string
+        [k: string]: unknown
+    }
+    export interface AppliedPagination {
+        /**
+         * `true` if we can  paginate to get more data.
+         */
+        has_more?: boolean
+        /**
+         * The specific page being returned.
+         */
+        page_number?: number
+        /**
+         * The number of results per page.
+         */
+        page_size?: number
+        /**
+         * Total number of entries.
+         */
+        total_count?: number
+        [k: string]: unknown
+    }
+}

--- a/packages/covalent-sdk/test/test.spec.ts
+++ b/packages/covalent-sdk/test/test.spec.ts
@@ -1,0 +1,21 @@
+import {assert, it} from 'vitest';
+import {Covalent} from '../src';
+
+assert(process.env.COVALENT_API_KEY, 'COVALENT_API_KEY env missing');
+const sdk = new Covalent.Client(process.env.COVALENT_API_KEY);
+
+it('getTokenBalancesForAddress', async () => {
+  const result = await sdk.getTokenBalancesForAddress({
+    chainId: Covalent.ChainId.ETHEREUM,
+    address: '0x6d9F1a927CBcb5e2c28D13CA735bc6d6131406da',
+  });
+  assert(result, 'no result');
+});
+
+it('getTransactionsForAddress', async () => {
+  const result = await sdk.getTransactionsForAddress({
+    chainId: Covalent.ChainId.ETHEREUM,
+    address: '0x6d9F1a927CBcb5e2c28D13CA735bc6d6131406da',
+  });
+  assert(result.items, 'items');
+}, 10_000);

--- a/packages/covalent-sdk/tsconfig.json
+++ b/packages/covalent-sdk/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "target": "es6",
+    "module": "esnext",
+    "lib": ["esnext"],
+    "importHelpers": true,
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "ts-node": {
+    // these options are overrides used only by ts-node
+    // same as the --compilerOptions flag and the TS_NODE_COMPILER_OPTIONS environment variable
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,6 +932,16 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
+"@bcherny/json-schema-ref-parser@10.0.5-fork":
+  version "10.0.5-fork"
+  resolved "https://registry.yarnpkg.com/@bcherny/json-schema-ref-parser/-/json-schema-ref-parser-10.0.5-fork.tgz#9b5e1e7e07964ea61840174098e634edbe8197bc"
+  integrity sha512-E/jKbPoca1tfUPj3iSbitDZTGnq6FUFjkH6L8U2oDwSuwK1WhnnVtCG7oFOTg/DDnyoXbQYUiUiGOibHqaGVnw==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@types/json-schema" "^7.0.6"
+    call-me-maybe "^1.0.1"
+    js-yaml "^4.1.0"
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -956,6 +966,16 @@
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
+
+"@esbuild/android-arm@0.15.18":
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.18.tgz#266d40b8fdcf87962df8af05b76219bc786b4f80"
+  integrity sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==
+
+"@esbuild/linux-loong64@0.15.18":
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz#128b76ecb9be48b60cf5cfc1c63a4f00691a3239"
+  integrity sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==
 
 "@ethereumjs/block@^3.5.0", "@ethereumjs/block@^3.6.0", "@ethereumjs/block@^3.6.2":
   version "3.6.2"
@@ -1959,6 +1979,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jsdevtools/ono@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
+  integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
 "@layerzerolabs/lz-sdk@latest":
   version "0.0.11"
@@ -3121,10 +3146,22 @@
   dependencies:
     "@types/node" "*"
 
+"@types/chai-subset@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
+  integrity sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==
+  dependencies:
+    "@types/chai" "*"
+
 "@types/chai@*":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
   integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
+
+"@types/chai@^4.3.3":
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.5.tgz#ae69bcbb1bebb68c4ac0b11e9d8ed04526b3562b"
+  integrity sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==
 
 "@types/concat-stream@^1.6.0":
   version "1.6.1"
@@ -3153,6 +3190,14 @@
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-0.0.33.tgz#c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8"
   integrity sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==
   dependencies:
+    "@types/node" "*"
+
+"@types/glob@^7.1.3":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
     "@types/node" "*"
 
 "@types/graceful-fs@^4.1.2":
@@ -3197,7 +3242,7 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/json-schema@^7.0.3":
+"@types/json-schema@^7.0.11", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.6":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
@@ -3221,10 +3266,20 @@
     "@types/level-errors" "*"
     "@types/node" "*"
 
+"@types/lodash@^4.14.182":
+  version "4.14.194"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
+  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
+
 "@types/lru-cache@^5.1.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
   integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -3277,6 +3332,11 @@
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
+
+"@types/prettier@^2.6.1":
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
+  integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
 
 "@types/qs@^6.2.31", "@types/qs@^6.9.7":
   version "6.9.7"
@@ -3597,6 +3657,11 @@ antlr4ts@^0.5.0-alpha.4:
   resolved "https://registry.yarnpkg.com/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz#71702865a87478ed0b40c0709f422cf14d51652a"
   integrity sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==
 
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -3642,6 +3707,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 aria-query@^4.2.2:
   version "4.2.2"
@@ -3764,6 +3834,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -4254,6 +4329,11 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
+call-me-maybe@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz#03f964f19522ba643b1b0693acb9152fe2074baa"
+  integrity sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==
+
 caller-callsite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
@@ -4314,6 +4394,19 @@ caseless@^0.12.0, caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
+chai@^4.3.6:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
+  integrity sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^4.1.2"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -4348,6 +4441,11 @@ chardet@^0.7.0:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 chokidar@3.3.0:
   version "3.3.0"
@@ -4416,6 +4514,17 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
+cli-color@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-2.0.3.tgz#73769ba969080629670f3f2ef69a4bf4e7cc1879"
+  integrity sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==
+  dependencies:
+    d "^1.0.1"
+    es5-ext "^0.10.61"
+    es6-iterator "^2.0.3"
+    memoizee "^0.4.15"
+    timers-ext "^0.1.7"
 
 cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
@@ -4895,6 +5004,14 @@ cssstyle@^2.0.0:
   dependencies:
     cssom "~0.3.6"
 
+d@1, d@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
+  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
+  dependencies:
+    es5-ext "^0.10.50"
+    type "^1.0.1"
+
 damerau-levenshtein@^1.0.7:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
@@ -4933,7 +5050,7 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -4986,6 +5103,13 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
+
+deep-eql@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
+  integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-is@~0.1.3:
   version "0.1.4"
@@ -5312,6 +5436,170 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@^0.10.61, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
+  version "0.10.62"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.62.tgz#5e6adc19a6da524bf3d1e02bbc8960e5eb49a9a5"
+  integrity sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==
+  dependencies:
+    es6-iterator "^2.0.3"
+    es6-symbol "^3.1.3"
+    next-tick "^1.1.0"
+
+es6-iterator@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
+  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
+  dependencies:
+    d "^1.0.1"
+    ext "^1.1.2"
+
+es6-weak-map@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
+  integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
+  dependencies:
+    d "1"
+    es5-ext "^0.10.46"
+    es6-iterator "^2.0.3"
+    es6-symbol "^3.1.1"
+
+esbuild-android-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz#20a7ae1416c8eaade917fb2453c1259302c637a5"
+  integrity sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==
+
+esbuild-android-arm64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz#9cc0ec60581d6ad267568f29cf4895ffdd9f2f04"
+  integrity sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==
+
+esbuild-darwin-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz#428e1730ea819d500808f220fbc5207aea6d4410"
+  integrity sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==
+
+esbuild-darwin-arm64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz#b6dfc7799115a2917f35970bfbc93ae50256b337"
+  integrity sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==
+
+esbuild-freebsd-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz#4e190d9c2d1e67164619ae30a438be87d5eedaf2"
+  integrity sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==
+
+esbuild-freebsd-arm64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz#18a4c0344ee23bd5a6d06d18c76e2fd6d3f91635"
+  integrity sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==
+
+esbuild-linux-32@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz#9a329731ee079b12262b793fb84eea762e82e0ce"
+  integrity sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==
+
+esbuild-linux-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz#532738075397b994467b514e524aeb520c191b6c"
+  integrity sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==
+
+esbuild-linux-arm64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz#5372e7993ac2da8f06b2ba313710d722b7a86e5d"
+  integrity sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==
+
+esbuild-linux-arm@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz#e734aaf259a2e3d109d4886c9e81ec0f2fd9a9cc"
+  integrity sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==
+
+esbuild-linux-mips64le@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz#c0487c14a9371a84eb08fab0e1d7b045a77105eb"
+  integrity sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==
+
+esbuild-linux-ppc64le@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz#af048ad94eed0ce32f6d5a873f7abe9115012507"
+  integrity sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==
+
+esbuild-linux-riscv64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz#423ed4e5927bd77f842bd566972178f424d455e6"
+  integrity sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==
+
+esbuild-linux-s390x@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz#21d21eaa962a183bfb76312e5a01cc5ae48ce8eb"
+  integrity sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==
+
+esbuild-netbsd-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz#ae75682f60d08560b1fe9482bfe0173e5110b998"
+  integrity sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==
+
+esbuild-openbsd-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz#79591a90aa3b03e4863f93beec0d2bab2853d0a8"
+  integrity sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==
+
+esbuild-sunos-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz#fd528aa5da5374b7e1e93d36ef9b07c3dfed2971"
+  integrity sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==
+
+esbuild-windows-32@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz#0e92b66ecdf5435a76813c4bc5ccda0696f4efc3"
+  integrity sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==
+
+esbuild-windows-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz#0fc761d785414284fc408e7914226d33f82420d0"
+  integrity sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==
+
+esbuild-windows-arm64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz#5b5bdc56d341d0922ee94965c89ee120a6a86eb7"
+  integrity sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==
+
+esbuild@^0.15.9:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.15.18.tgz#ea894adaf3fbc036d32320a00d4d6e4978a2f36d"
+  integrity sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.15.18"
+    "@esbuild/linux-loong64" "0.15.18"
+    esbuild-android-64 "0.15.18"
+    esbuild-android-arm64 "0.15.18"
+    esbuild-darwin-64 "0.15.18"
+    esbuild-darwin-arm64 "0.15.18"
+    esbuild-freebsd-64 "0.15.18"
+    esbuild-freebsd-arm64 "0.15.18"
+    esbuild-linux-32 "0.15.18"
+    esbuild-linux-64 "0.15.18"
+    esbuild-linux-arm "0.15.18"
+    esbuild-linux-arm64 "0.15.18"
+    esbuild-linux-mips64le "0.15.18"
+    esbuild-linux-ppc64le "0.15.18"
+    esbuild-linux-riscv64 "0.15.18"
+    esbuild-linux-s390x "0.15.18"
+    esbuild-netbsd-64 "0.15.18"
+    esbuild-openbsd-64 "0.15.18"
+    esbuild-sunos-64 "0.15.18"
+    esbuild-windows-32 "0.15.18"
+    esbuild-windows-64 "0.15.18"
+    esbuild-windows-arm64 "0.15.18"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -5830,6 +6118,14 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
+event-emitter@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  integrity sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -5941,6 +6237,13 @@ expect@^25.5.0:
     jest-matcher-utils "^25.5.0"
     jest-message-util "^25.5.0"
     jest-regex-util "^25.2.6"
+
+ext@^1.1.2:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.7.0.tgz#0ea4383c0103d60e70be99e9a7f11027a33c4f5f"
+  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
+  dependencies:
+    type "^2.7.2"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -6332,6 +6635,11 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
@@ -6370,6 +6678,11 @@ get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
+get-stdin@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
+  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -6465,6 +6778,13 @@ glob-parent@^5.0.0, glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.0, 
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
+
+glob-promise@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-4.2.2.tgz#15f44bcba0e14219cd93af36da6bb905ff007877"
+  integrity sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==
+  dependencies:
+    "@types/glob" "^7.1.3"
 
 glob@7.1.3:
   version "7.1.3"
@@ -7151,6 +7471,13 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-core-module@^2.11.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.0.tgz#36ad62f6f73c8253fd6472517a12483cf03e7ec4"
+  integrity sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==
+  dependencies:
+    has "^1.0.3"
+
 is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-module@^2.8.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
@@ -7323,6 +7650,11 @@ is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
+is-promise@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
+  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
 is-reference@^1.1.2:
   version "1.2.1"
@@ -7923,6 +8255,13 @@ js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsbi@^3.1.4:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-3.2.5.tgz#b37bb90e0e5c2814c1c2a1bcd8c729888a2e37d6"
@@ -7984,6 +8323,26 @@ json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
+json-schema-to-typescript@^11.0.1:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/json-schema-to-typescript/-/json-schema-to-typescript-11.0.5.tgz#04020422b7970e1c3b2ee8b601548e8751e1cd03"
+  integrity sha512-ZNlvngzlPzjYYECbR+uJ9aUWo25Gw/VuwUytvcuKiwc6NaiZhMyf7qBsxZE2eixmj8AoQEQJhSRG7btln0sUDw==
+  dependencies:
+    "@bcherny/json-schema-ref-parser" "10.0.5-fork"
+    "@types/json-schema" "^7.0.11"
+    "@types/lodash" "^4.14.182"
+    "@types/prettier" "^2.6.1"
+    cli-color "^2.0.2"
+    get-stdin "^8.0.0"
+    glob "^7.1.6"
+    glob-promise "^4.2.2"
+    is-glob "^4.0.3"
+    lodash "^4.17.21"
+    minimist "^1.2.6"
+    mkdirp "^1.0.4"
+    mz "^2.7.0"
+    prettier "^2.6.2"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -8274,6 +8633,11 @@ load-json-file@^6.2.0:
     strip-bom "^4.0.0"
     type-fest "^0.6.0"
 
+local-pkg@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.3.tgz#0ff361ab3ae7f1c19113d9bb97b98b905dbc4963"
+  integrity sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -8342,7 +8706,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.7.0:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8377,6 +8741,13 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^2.3.1:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.6.tgz#76e4af498103c532d1ecc9be102036a21f787b53"
+  integrity sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==
+  dependencies:
+    get-func-name "^2.0.0"
+
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
@@ -8397,6 +8768,13 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
+  integrity sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==
+  dependencies:
+    es5-ext "~0.10.2"
 
 lru_map@^0.3.3:
   version "0.3.3"
@@ -8542,6 +8920,20 @@ memdown@^5.0.0:
     inherits "~2.0.1"
     ltgt "~2.2.0"
     safe-buffer "~5.2.0"
+
+memoizee@^0.4.15:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
+  integrity sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==
+  dependencies:
+    d "^1.0.1"
+    es5-ext "^0.10.53"
+    es6-weak-map "^2.0.3"
+    event-emitter "^0.3.5"
+    is-promise "^2.2.2"
+    lru-queue "^0.1.0"
+    next-tick "^1.1.0"
+    timers-ext "^0.1.7"
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -8897,6 +9289,20 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mz@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
+nanoid@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -8928,6 +9334,11 @@ neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+next-tick@1, next-tick@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
+  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -9200,7 +9611,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -9617,6 +10028,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 pbkdf2@^3.0.17:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
@@ -9685,6 +10101,15 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==
 
+postcss@^8.4.18:
+  version "8.4.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.23.tgz#df0aee9ac7c5e53e1075c24a3613496f9e6552ab"
+  integrity sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==
+  dependencies:
+    nanoid "^3.3.6"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -9706,6 +10131,11 @@ prettier@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
   integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+
+prettier@^2.7.1:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^24.9.0:
   version "24.9.0"
@@ -10253,6 +10683,15 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.14
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@^1.22.1:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
+  integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
+  dependencies:
+    is-core-module "^2.11.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.3.tgz#d41016293d4a8586a39ca5d9b5f15cbea1f55e46"
@@ -10373,6 +10812,13 @@ rollup@^1.32.1:
     "@types/estree" "*"
     "@types/node" "*"
     acorn "^7.1.0"
+
+rollup@^2.79.1:
+  version "2.79.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
+  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -10745,6 +11191,11 @@ sort-keys@^4.0.0:
   integrity sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==
   dependencies:
     is-plain-obj "^2.0.0"
+
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"
@@ -11250,6 +11701,20 @@ then-request@^6.0.0:
     promise "^8.0.0"
     qs "^6.4.0"
 
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
+
 throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
@@ -11275,6 +11740,14 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+timers-ext@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.7.tgz#6f57ad8578e07a3fb9f91d9387d65647555e25c6"
+  integrity sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==
+  dependencies:
+    es5-ext "~0.10.46"
+    next-tick "1"
+
 tiny-glob@^0.2.6:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.9.tgz#2212d441ac17928033b110f8b3640683129d31e2"
@@ -11282,6 +11755,16 @@ tiny-glob@^0.2.6:
   dependencies:
     globalyzer "0.1.0"
     globrex "^0.1.2"
+
+tinypool@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.2.4.tgz#4d2598c4689d1a2ce267ddf3360a9c6b3925a20c"
+  integrity sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==
+
+tinyspy@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-1.1.1.tgz#0cb91d5157892af38cb2d217f5c7e8507a5bf092"
+  integrity sha512-UVq5AXt/gQlti7oxoIg5oi/9r0WpF7DGEVwXgqWSMmyN16+e3tl5lIvTaOpJ3TAtu5xFzWccFRM4R5NaWHF+4g==
 
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
@@ -11408,6 +11891,25 @@ ts-node@^10.6.0:
   version "10.8.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.1.tgz#ea2bd3459011b52699d7e88daa55a45a1af4f066"
   integrity sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"
@@ -11551,7 +12053,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
@@ -11586,6 +12088,16 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
+  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
+
+type@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.7.2.tgz#2376a15a3a28b1efa0f5350dcf72d24df6ef98d0"
+  integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -11607,6 +12119,11 @@ typescript@^4.6.2:
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
   integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
+
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uglify-js@^3.1.4:
   version "3.16.0"
@@ -11799,6 +12316,33 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+"vite@^2.9.12 || ^3.0.0-0":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-3.2.6.tgz#a0538710e69532225d9c0ba6a23f4158b51267fd"
+  integrity sha512-nTXTxYVvaQNLoW5BQ8PNNQ3lPia57gzsQU/Khv+JvzKPku8kNZL6NMUR/qwXhMG6E+g1idqEPanomJ+VZgixEg==
+  dependencies:
+    esbuild "^0.15.9"
+    postcss "^8.4.18"
+    resolve "^1.22.1"
+    rollup "^2.79.1"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+vitest@^0.21.0:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.21.1.tgz#b4f5b901c9a23a3aaec76d3404f3072821d93d00"
+  integrity sha512-WBIxuFmIDPuK47GO6Lu9eNeRMqHj/FWL3dk73OHH3eyPPWPiu+UB3QHLkLK2PEggCqJW4FaWoWg8R68S7p9+9Q==
+  dependencies:
+    "@types/chai" "^4.3.3"
+    "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
+    chai "^4.3.6"
+    debug "^4.3.4"
+    local-pkg "^0.4.2"
+    tinypool "^0.2.4"
+    tinyspy "^1.0.0"
+    vite "^2.9.12 || ^3.0.0-0"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Since covalent-sdk only seems to be used by `omnichain-api` and is not strictly related to the UI monorepo, moving it here makes more sense than maintaining it in the soon-to-be-public ui-monorepo